### PR TITLE
chore: fix infra

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -10,5 +10,5 @@
 	"access": "public",
 	"baseBranch": "main",
 	"updateInternalDependencies": "patch",
-	"ignore": []
+	"ignore": ["shilpcss-docs"]
 }

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,9 +1,0 @@
-{
-  "mode": "pre",
-  "tag": "alpha",
-  "initialVersions": {
-    "shilpcss-docs": "1.0.0-alpha.0",
-    "shilpcss": "1.0.0-alpha.0"
-  },
-  "changesets": []
-}

--- a/.changeset/rare-boats-feel.md
+++ b/.changeset/rare-boats-feel.md
@@ -1,5 +1,0 @@
----
-"shilpcss-docs": patch
----
-
-Fix typos and docs link styles, improve content

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -2,7 +2,6 @@ name: "Feature Request"
 description: Suggest a new feature or improvement for ShilpCSS
 title: "[feat]: "
 labels: ["area: request"]
-
 body:
   - type: markdown
     attributes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.0.0-alpha.1
+
+### Patch Changes
+
+- Remove "shilpcss-docs" from changeset
+
 ## 1.0.0-alpha.0
 
 शुभारम्भः

--- a/apps/docs/CHANGELOG.md
+++ b/apps/docs/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 1.0.0-alpha.1
+
+### Patch Changes
+
+- docs: fix typos and docs link styles, improve content
+  - Fix docs active link styles affected by
+  - Fix few typos in content
+  - Improve intro line of [ Work With Me ] page
+
 ## 1.0.0-alpha.0
 
 शुभारम्भः

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "shilpcss-docs",
 	"description": "Shilp CSS documentation",
-	"version": "1.0.0-alpha.0",
+	"version": "1.0.0-alpha.1",
 	"type": "module",
 	"private": true,
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "shilpcss-monorepo",
 	"description": "Shilp CSS monorepo",
-	"version": "1.0.0-alpha.0",
+	"version": "1.0.0-alpha.1",
 	"private": true,
 	"type": "module",
 	"scripts": {


### PR DESCRIPTION
- ignore "shilpcss-docs" from changesets
- bump "shilpcss-docs" version and update changelog (missed due to changeset config)
- update monorepo version and changelog