### PR TITLE
docs: improve frontmatter and fix typos in pathname

### DIFF
--- a/apps/docs/CHANGELOG.md
+++ b/apps/docs/CHANGELOG.md
@@ -8,6 +8,9 @@
   - Add description
   - Add keywords
   - Improve title
+- Fix duplicate `h1`
+- Fix wrong pathnames
+- Reduce title length of "/work-with-me" page
 
 ## 1.0.0-alpha.3
 

--- a/apps/docs/CHANGELOG.md
+++ b/apps/docs/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 1.0.0-alpha.4
+
+## Patch Changes
+
+- Improve frontmatter data for docs pages
+  - Add description
+  - Add keywords
+  - Improve title
+
 ## 1.0.0-alpha.3
 
 ### Patch Changes

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "shilpcss-docs",
 	"description": "Shilp CSS documentation",
-	"version": "1.0.0-alpha.3",
+	"version": "1.0.0-alpha.4",
 	"type": "module",
 	"private": true,
 	"scripts": {

--- a/apps/docs/src/app/work-with-me/page.jsx
+++ b/apps/docs/src/app/work-with-me/page.jsx
@@ -6,8 +6,7 @@ import Separator from "@/components/separator";
 export const metadata = {
 	//
 	title: {
-		absolute:
-			"Work With the Creator of Shilp CSS, Frontend Engineer | Pradipsinh Jadeja",
+		absolute: "Work With Shilp CSS Creator - Pradipsinh Jadeja",
 	},
 
 	description:

--- a/apps/docs/src/content/docs/(core-concepts)/browser-compatibility.mdx
+++ b/apps/docs/src/content/docs/(core-concepts)/browser-compatibility.mdx
@@ -1,5 +1,16 @@
 ---
-title: "Browser Compatibility"
+title: "Browser Compatibility and Baseline Requirements"
+description:
+  "Shilp CSS browser support: Chrome 109+, Safari 16.3+, Edge 109+, Firefox
+  109+. Clear baseline, no legacy fallbacks."
+keywords:
+  [
+    "browser support",
+    "compatibility",
+    "modern browsers",
+    "baseline",
+    "Lightning CSS",
+  ]
 ---
 
 # Browser Compatibility

--- a/apps/docs/src/content/docs/(core-concepts)/colors.mdx
+++ b/apps/docs/src/content/docs/(core-concepts)/colors.mdx
@@ -1,5 +1,16 @@
 ---
-title: "Colors"
+title: "Color System in Shilp CSS"
+description:
+  "Discover Shilp CSS color system using OKLCH format. Curated palette, semantic
+  color tokens, and default dark mode support."
+keywords:
+  [
+    "color system",
+    "OKLCH format",
+    "design tokens",
+    "color palette",
+    "dark mode",
+  ]
 ---
 
 # Colors

--- a/apps/docs/src/content/docs/(core-concepts)/dark-mode.mdx
+++ b/apps/docs/src/content/docs/(core-concepts)/dark-mode.mdx
@@ -1,5 +1,16 @@
 ---
-title: "Dark Mode"
+title: "Dark Mode Implementation Guide"
+description:
+  "Implement dark mode in Shilp CSS using class-based approach. Learn theme
+  mixins and dark mode toggle patterns."
+keywords:
+  [
+    "dark mode",
+    "theme switching",
+    "CSS variables",
+    "light mode",
+    "accessibility",
+  ]
 ---
 
 # Dark Mode

--- a/apps/docs/src/content/docs/(core-concepts)/index.mdx
+++ b/apps/docs/src/content/docs/(core-concepts)/index.mdx
@@ -1,5 +1,10 @@
 ---
-title: "Core Concepts"
+title: "Core Concepts Overview"
+description:
+  "Explore Shilp CSS core concepts: intents, theming, responsive design, colors,
+  dark mode, and browser compatibility for modern CSS."
+keywords:
+  ["core concepts", "CSS fundamentals", "responsive design", "theming system"]
 ---
 
 # Core Concepts

--- a/apps/docs/src/content/docs/(core-concepts)/responsive-design.mdx
+++ b/apps/docs/src/content/docs/(core-concepts)/responsive-design.mdx
@@ -1,5 +1,16 @@
 ---
-title: "Responsive Design"
+title: "Responsive Design in Shilp CSS"
+description:
+  "Master responsive design with Shilp CSS breakpoints. Mobile-first approach,
+  default breakpoints, and responsive utilities."
+keywords:
+  [
+    "responsive design",
+    "breakpoints",
+    "mobile-first",
+    "media queries",
+    "screen sizes",
+  ]
 ---
 
 # Responsive Design

--- a/apps/docs/src/content/docs/(core-concepts)/styling-with-intent.mdx
+++ b/apps/docs/src/content/docs/(core-concepts)/styling-with-intent.mdx
@@ -1,5 +1,15 @@
 ---
-title: "Styling with Intent"
+title: "Styling with Intent - Core Concept"
+description:
+  "Learn intent-based styling in Shilp CSS. Organize styles by responsibility
+  using intents like @layout, @text, @bg, and stateful mixins."
+keywords:
+  [
+    "intent-based styling",
+    "styling methodology",
+    "CSS organization",
+    "responsibilities",
+  ]
 ---
 
 # Styling With Intent

--- a/apps/docs/src/content/docs/(core-concepts)/theming.mdx
+++ b/apps/docs/src/content/docs/(core-concepts)/theming.mdx
@@ -1,5 +1,16 @@
 ---
-title: "Theming"
+title: "Theming and Design Tokens"
+description:
+  "Master theming in Shilp CSS. Create design tokens, semantic color systems,
+  and customize typography and spacing."
+keywords:
+  [
+    "theming",
+    "design tokens",
+    "customization",
+    "design system",
+    "CSS variables",
+  ]
 ---
 
 # Theming

--- a/apps/docs/src/content/docs/(root)/benchmarks.mdx
+++ b/apps/docs/src/content/docs/(root)/benchmarks.mdx
@@ -1,5 +1,10 @@
 ---
-title: "Benchmarks"
+title: "Shilp CSS Performance Benchmarks"
+description:
+  "Compare Shilp CSS performance metrics with other CSS frameworks. View build
+  time and output size benchmarks for different projects."
+keywords:
+  ["benchmarks", "performance", "CSS framework comparison", "build speed"]
 ---
 
 # Benchmarks

--- a/apps/docs/src/content/docs/(root)/credits.mdx
+++ b/apps/docs/src/content/docs/(root)/credits.mdx
@@ -1,11 +1,15 @@
 ---
-title: "Credits"
+title: "Credits and Acknowledgments"
+description:
+  "Credits to the tools, libraries, and individuals that made Shilp CSS
+  possible. Thank you to our inspiration sources."
+keywords: ["credits", "acknowledgments", "dependencies", "open source"]
 ---
 
 # Credits
 
-Thanks to the tools and dependencies Shilp CSS builds upon or got the inspiration, and the individuals,
-teams, and organizations behind them.
+Thanks to the tools and dependencies Shilp CSS builds upon or got the
+inspiration, and the individuals, teams, and organizations behind them.
 
 This wouldn’t be possible without their work.
 

--- a/apps/docs/src/content/docs/(root)/index.mdx
+++ b/apps/docs/src/content/docs/(root)/index.mdx
@@ -1,5 +1,17 @@
 ---
 title: "Shilp CSS Introduction"
+description:
+  "Learn Shilp CSS, an intent-first CSS-centric styling engine that keeps styles
+  in CSS files instead of HTML markup for better maintainability."
+keywords:
+  [
+    "Shilp CSS",
+    "Modern",
+    "CSS Engine",
+    "CSS framework",
+    "intent-based styling",
+    "semantic CSS",
+  ]
 ---
 
 # Shilp CSS Introduction

--- a/apps/docs/src/content/docs/(root)/mental-model.mdx
+++ b/apps/docs/src/content/docs/(root)/mental-model.mdx
@@ -1,5 +1,10 @@
 ---
-title: "Mental Model"
+title: "Shilp CSS Mental Model"
+description:
+  "Master the core principle that styles belong in CSS. Learn how to think about
+  intent-based styling for maintainable design systems."
+keywords:
+  ["mental model", "CSS mindset", "styling approach", "Shilp CSS philosophy"]
 ---
 
 # Mental Model

--- a/apps/docs/src/content/docs/(root)/quick-overview.mdx
+++ b/apps/docs/src/content/docs/(root)/quick-overview.mdx
@@ -1,5 +1,10 @@
 ---
-title: "Quick Overview"
+title: "Shilp CSS Quick Overview"
+description:
+  "Get a quick introduction to Shilp CSS architecture: intent-based styling,
+  static CSS output, and how it processes styles at build time."
+keywords:
+  ["Shilp CSS architecture", "CSS processing", "build time", "intent system"]
 ---
 
 # Quick Overview

--- a/apps/docs/src/content/docs/(root)/setup.mdx
+++ b/apps/docs/src/content/docs/(root)/setup.mdx
@@ -1,5 +1,10 @@
 ---
-title: "Setup Shilp CSS"
+title: "How to Setup Shilp CSS"
+description:
+  "Step-by-step installation guide for Shilp CSS with Vite and Webpack.
+  Configure bundler plugins and optimize your styling workflow."
+keywords:
+  ["installation", "setup guide", "Vite plugin", "Webpack", "configuration"]
 ---
 
 # Setup Shilp CSS

--- a/apps/docs/src/content/docs/(root)/status.mdx
+++ b/apps/docs/src/content/docs/(root)/status.mdx
@@ -51,8 +51,7 @@ Shilp CSS is solid in its fundamentals:
 - Static, purgeable output
 - Modern CSS via **Lightning CSS**
 - Clear browser support baseline
-  - More at
-    [Browser Compatibility](/docs/is-it-production-ready#browser-compatibility)
+  - More at [Browser Compatibility](#browser-compatibility)
 - No runtime
 - No framework lock-in
 - Great defaults styles
@@ -171,7 +170,7 @@ acknowledged openly rather than hidden.
 
 <section>
 
-# Support & Maintenance
+## Support & Maintenance
 
 Shilp CSS is currently crafted by the team of
 [one person](https://x.com/jadeja97_).

--- a/apps/docs/src/content/docs/(root)/status.mdx
+++ b/apps/docs/src/content/docs/(root)/status.mdx
@@ -1,5 +1,10 @@
 ---
-title: "Shilp CSS Status"
+title: "Shilp CSS Status and Stability"
+description:
+  "Check Shilp CSS current development status. Alpha version with stable mental
+  model, core architecture, and real-world usage ready."
+keywords:
+  ["alpha version", "development status", "stability", "production readiness"]
 ---
 
 # Shilp CSS Status

--- a/apps/docs/src/content/docs/(root)/why-shilp-css.mdx
+++ b/apps/docs/src/content/docs/(root)/why-shilp-css.mdx
@@ -1,5 +1,15 @@
 ---
-title: "Why Shilp CSS?"
+title: "Why Shilp CSS? The Case for Intent-Based Styling"
+description:
+  "Understand why intent-based CSS styling scales better than utility-first
+  approaches and reduces hidden coupling in large design systems."
+keywords:
+  [
+    "utility-first CSS",
+    "design systems",
+    "CSS scalability",
+    "intent-based styling",
+  ]
 ---
 
 # Why Shilp CSS?

--- a/apps/docs/src/content/docs/best-practices/index.mdx
+++ b/apps/docs/src/content/docs/best-practices/index.mdx
@@ -1,5 +1,16 @@
 ---
-title: "Best Practices Overview"
+title: "Best Practices for Shilp CSS"
+description:
+  "Learn best practices for writing maintainable Shilp CSS. Naming conventions,
+  organization patterns, and efficient styling strategies."
+keywords:
+  [
+    "best practices",
+    "naming conventions",
+    "code organization",
+    "style guide",
+    "CSS naming",
+  ]
 ---
 
 # Best Practices Overview

--- a/apps/docs/src/content/docs/best-practices/multi-theme.mdx
+++ b/apps/docs/src/content/docs/best-practices/multi-theme.mdx
@@ -1,5 +1,9 @@
 ---
-title: "Multi Theme"
+title: "Multi-Theme Implementation"
+description:
+  "Create multiple themes in Shilp CSS using theme mixin variants. Configure and
+  switch between themes dynamically."
+keywords: ["multi-theme", "theme switching", "theme variants", "customization"]
 ---
 
 # Multi Theme

--- a/apps/docs/src/content/docs/best-practices/property-config-patterns.mdx
+++ b/apps/docs/src/content/docs/best-practices/property-config-patterns.mdx
@@ -1,5 +1,16 @@
 ---
-title: "Property Config Patterns"
+title: "Property Configuration Patterns"
+description:
+  "Explore 8 common property config patterns in Shilp CSS. Learn utilities
+  structure, variants, presets, and CSS variables."
+keywords:
+  [
+    "property config",
+    "configuration patterns",
+    "utilities",
+    "presets",
+    "CSS variables",
+  ]
 ---
 
 # Property Config Patterns

--- a/apps/docs/src/content/docs/best-practices/writing-shilp-css.mdx
+++ b/apps/docs/src/content/docs/best-practices/writing-shilp-css.mdx
@@ -1,5 +1,16 @@
 ---
-title: "Best Practices for Writing Shilp CSS"
+title: "Writing Shilp CSS: Naming, Organization, and Patterns"
+description:
+  "Master the art of naming roles in Shilp CSS. Avoid naming colors, learn
+  organizational patterns, and write maintainable styles."
+keywords:
+  [
+    "naming",
+    "writing styles",
+    "role-based naming",
+    "organization patterns",
+    "maintenance",
+  ]
 ---
 
 # Best Practices For Writing Shilp CSS

--- a/apps/docs/src/content/docs/components/container.mdx
+++ b/apps/docs/src/content/docs/components/container.mdx
@@ -1,5 +1,10 @@
 ---
-title: "Container Component"
+title: "Container Component for Layout"
+description:
+  "Use the container component for consistent content width across breakpoints.
+  Alignment helpers and configuration options."
+keywords:
+  ["container", "component", "layout", "breakpoints", "responsive container"]
 ---
 
 # Container Component

--- a/apps/docs/src/content/docs/components/index.mdx
+++ b/apps/docs/src/content/docs/components/index.mdx
@@ -1,5 +1,10 @@
 ---
-title: "Components Overview"
+title: "Component Classes in Shilp CSS"
+description:
+  "Understand Shilp CSS components: static and dynamic classes. Learn when to
+  use components vs utilities."
+keywords:
+  ["components", "component classes", "static components", "dynamic components"]
 ---
 
 # Components Overview

--- a/apps/docs/src/content/docs/components/limit-lines.mdx
+++ b/apps/docs/src/content/docs/components/limit-lines.mdx
@@ -1,5 +1,10 @@
 ---
-title: "Limit Lines Component"
+title: "Limit Lines Component - Text Truncation"
+description:
+  "Truncate text to a fixed number of lines with the limit-lines component.
+  Perfect for cards and content previews."
+keywords:
+  ["text truncation", "line clamp", "limit lines", "text overflow", "component"]
 ---
 
 # Limit Lines Component

--- a/apps/docs/src/content/docs/components/screen-reader.mdx
+++ b/apps/docs/src/content/docs/components/screen-reader.mdx
@@ -1,5 +1,10 @@
 ---
-title: "Screen Reader Component"
+title: "Screen Reader Component for Accessibility"
+description:
+  "Hide content visually while keeping it accessible to screen readers.
+  Essential accessibility pattern for inclusive design."
+keywords:
+  ["accessibility", "screen reader", "accessible", "inclusive design", "ARIA"]
 ---
 
 # Screen Reader Component

--- a/apps/docs/src/content/docs/config/components.mdx
+++ b/apps/docs/src/content/docs/config/components.mdx
@@ -1,5 +1,15 @@
 ---
-title: "Components"
+title: "Components Configuration"
+description:
+  "Configure static and dynamic component classes in Shilp CSS. Learn generation
+  patterns and usage."
+keywords:
+  [
+    "component configuration",
+    "static components",
+    "dynamic generation",
+    "config setup",
+  ]
 ---
 
 # Components

--- a/apps/docs/src/content/docs/config/index.mdx
+++ b/apps/docs/src/content/docs/config/index.mdx
@@ -1,5 +1,10 @@
 ---
-title: "Configuration's Overview"
+title: "Shilp CSS Configuration Overview"
+description:
+  "Master Shilp CSS configuration. Control properties, theme, values, utilities,
+  components, and mixins from shilp.config.js."
+keywords:
+  ["configuration", "config", "setup", "shilp.config.js", "customization"]
 ---
 
 # Configuration

--- a/apps/docs/src/content/docs/config/index.mdx
+++ b/apps/docs/src/content/docs/config/index.mdx
@@ -233,7 +233,7 @@ That’s it.
 
 Below is the basic structure of `shilp.config.js` file. For a deeper explanation
 of how the file is processed, see
-[Shilp Config File](/config/shilp-config-file).
+[Shilp Config File](/docs/config/shilp-config-file).
 
 ```js title="shilp.config.js"
 const shilpConfig = {

--- a/apps/docs/src/content/docs/config/intents.mdx
+++ b/apps/docs/src/content/docs/config/intents.mdx
@@ -1,5 +1,9 @@
 ---
-title: "Intents"
+title: "Intents Configuration and Syntax"
+description:
+  "Configure and use intents in Shilp CSS. Intent syntax, parsing, registration,
+  and default intent list."
+keywords: ["intents", "intent-based styling", "intent config", "intent system"]
 ---
 
 # Intents

--- a/apps/docs/src/content/docs/config/mixins.mdx
+++ b/apps/docs/src/content/docs/config/mixins.mdx
@@ -1,5 +1,9 @@
 ---
-title: "Mixins"
+title: "Mixins Configuration"
+description:
+  "Configure stateful intents in Shilp CSS. Define mixins for states, themes,
+  breakpoints, and custom conditions."
+keywords: ["mixins", "stateful intents", "conditions", "CSS selectors"]
 ---
 
 # Mixins

--- a/apps/docs/src/content/docs/config/properties.mdx
+++ b/apps/docs/src/content/docs/config/properties.mdx
@@ -1,5 +1,15 @@
 ---
-title: "Properties"
+title: "Properties Configuration"
+description:
+  "Configure CSS properties in Shilp CSS. Define utilities, resolve values,
+  manage property variants and special behaviors."
+keywords:
+  [
+    "property configuration",
+    "CSS properties",
+    "utility generation",
+    "property config",
+  ]
 ---
 
 # Properties

--- a/apps/docs/src/content/docs/config/shilp-config-file.mdx
+++ b/apps/docs/src/content/docs/config/shilp-config-file.mdx
@@ -1,5 +1,10 @@
 ---
-title: "Shilp Config File"
+title: "Shilp Config File Reference"
+description:
+  "Complete reference for shilp.config.js structure. Configure values, theme,
+  properties, intents, mixins, and build options."
+keywords:
+  ["shilp.config.js", "configuration file", "build config", "JavaScript config"]
 ---
 
 # Shilp Config File

--- a/apps/docs/src/content/docs/config/theme.mdx
+++ b/apps/docs/src/content/docs/config/theme.mdx
@@ -1,5 +1,9 @@
 ---
-title: "Theme"
+title: "Theme Configuration and Usage"
+description:
+  "Configure theming in Shilp CSS. Structure datasets, inline theme function,
+  and design token management."
+keywords: ["theme configuration", "design tokens", "theming", "theme system"]
 ---
 
 # Theme

--- a/apps/docs/src/content/docs/config/theme.mdx
+++ b/apps/docs/src/content/docs/config/theme.mdx
@@ -277,7 +277,7 @@ export default shilpConfig;
 
 #### Avilable Options
 
-See: [Custom Value Resolver](/docs/config/value#custom-resolver)
+See: [Custom Value Resolver](/docs/config/values#custom-resolver)
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/config/utilities.mdx
+++ b/apps/docs/src/content/docs/config/utilities.mdx
@@ -1,5 +1,10 @@
 ---
-title: "Utilities"
+title: "Utilities Configuration"
+description:
+  "Understand how utilities work in Shilp CSS. Utility parsing, values,
+  variants, negatives, and important flags."
+keywords:
+  ["utilities", "utility syntax", "utility parsing", "utility configuration"]
 ---
 
 # Utilities

--- a/apps/docs/src/content/docs/config/values.mdx
+++ b/apps/docs/src/content/docs/config/values.mdx
@@ -1,5 +1,15 @@
 ---
-title: "Values"
+title: "Values Configuration and Resolvers"
+description:
+  "Configure primitive values in Shilp CSS. Value datasets, resolvers, and
+  custom value processing."
+keywords:
+  [
+    "values configuration",
+    "value resolvers",
+    "primitive values",
+    "custom resolvers",
+  ]
 ---
 
 # Values

--- a/apps/docs/src/content/docs/default-styles/animate.mdx
+++ b/apps/docs/src/content/docs/default-styles/animate.mdx
@@ -161,8 +161,7 @@ html,
 
 This approach updates the entire system consistently.
 
-See:
-[Modifying Default Styles](/docs/default-styles/overview#modifying-default-styles).
+See: [Modifying Default Styles](/docs/default-styles#modifying-default-styles).
 
 </section>
 

--- a/apps/docs/src/content/docs/default-styles/animate.mdx
+++ b/apps/docs/src/content/docs/default-styles/animate.mdx
@@ -1,5 +1,8 @@
 ---
-title: "animate.css"
+title: "Animation Keyframes Stylesheet"
+description:
+  "Animation keyframes stylesheet. Default animation effects for Shilp CSS."
+keywords: ["animate.css", "animations", "keyframes", "animation effects"]
 ---
 
 # animate.css

--- a/apps/docs/src/content/docs/default-styles/base.mdx
+++ b/apps/docs/src/content/docs/default-styles/base.mdx
@@ -231,8 +231,7 @@ Example:
 
 This approach updates the entire system consistently.
 
-See:
-[Modifying Default Styles](/docs/default-styles/overview#modifying-default-styles).
+See: [Modifying Default Styles](/docs/default-styles#modifying-default-styles).
 
 </section>
 

--- a/apps/docs/src/content/docs/default-styles/base.mdx
+++ b/apps/docs/src/content/docs/default-styles/base.mdx
@@ -1,5 +1,8 @@
 ---
-title: "base.css"
+title: "Base Stylesheet"
+description:
+  "Base stylesheet with fundamental default styles for Shilp CSS projects."
+keywords: ["base.css", "base styles", "default stylesheet"]
 ---
 
 # base.css

--- a/apps/docs/src/content/docs/default-styles/colors-dark-flip-base.mdx
+++ b/apps/docs/src/content/docs/default-styles/colors-dark-flip-base.mdx
@@ -187,8 +187,7 @@ html,
 Because components and utilities rely on variables, the entire UI will update
 automatically.
 
-See:
-[Modifying Default Styles](/docs/default-styles/overview#modifying-default-styles).
+See: [Modifying Default Styles](/docs/default-styles#modifying-default-styles).
 
 </section>
 

--- a/apps/docs/src/content/docs/default-styles/colors-dark-flip-base.mdx
+++ b/apps/docs/src/content/docs/default-styles/colors-dark-flip-base.mdx
@@ -1,5 +1,15 @@
 ---
-title: "colors-dark-flip-base.css"
+title: "Dark Theme with Flipped Palette"
+description:
+  "Alternative dark theme strategy using flipped color scales instead of
+  separate palette."
+keywords:
+  [
+    "colors-dark-flip-base.css",
+    "dark theme",
+    "flipped colors",
+    "palette strategy",
+  ]
 ---
 
 # colors-dark-flip-base.css

--- a/apps/docs/src/content/docs/default-styles/colors-dark.mdx
+++ b/apps/docs/src/content/docs/default-styles/colors-dark.mdx
@@ -172,8 +172,7 @@ html,
 Because components and utilities rely on variables, the entire UI will update
 automatically.
 
-See:
-[Modifying Default Styles](/docs/default-styles/overview#modifying-default-styles).
+See: [Modifying Default Styles](/docs/default-styles#modifying-default-styles).
 
 </section>
 

--- a/apps/docs/src/content/docs/default-styles/colors-dark.mdx
+++ b/apps/docs/src/content/docs/default-styles/colors-dark.mdx
@@ -1,5 +1,9 @@
 ---
-title: "colors-dark.css"
+title: "Dark Theme Colors Stylesheet"
+description:
+  "Dark theme color variables stylesheet. Paired colors for dark mode CSS
+  variables."
+keywords: ["colors-dark.css", "dark mode colors", "dark theme", "color palette"]
 ---
 
 # colors-dark.css

--- a/apps/docs/src/content/docs/default-styles/colors.mdx
+++ b/apps/docs/src/content/docs/default-styles/colors.mdx
@@ -1,5 +1,9 @@
 ---
-title: "colors.css"
+title: "Colors Stylesheet - Theme Variables"
+description:
+  "Color design system stylesheet. CSS variables for light theme colors and
+  semantic color roles."
+keywords: ["colors.css", "color variables", "CSS variables", "theme colors"]
 ---
 
 # colors.css

--- a/apps/docs/src/content/docs/default-styles/colors.mdx
+++ b/apps/docs/src/content/docs/default-styles/colors.mdx
@@ -185,8 +185,7 @@ html,
 Because components and utilities rely on variables, the entire UI will update
 automatically.
 
-See:
-[Modifying Default Styles](/docs/default-styles/overview#modifying-default-styles)
+See: [Modifying Default Styles](/docs/default-styles#modifying-default-styles)
 
 </section>
 

--- a/apps/docs/src/content/docs/default-styles/components.mdx
+++ b/apps/docs/src/content/docs/default-styles/components.mdx
@@ -122,8 +122,7 @@ For more complex UI patterns, it is usually better to write styles directly.
 
 You can override in your own styles.
 
-See:
-[Modifying Default Styles](/docs/default-styles/overview#modifying-default-styles).
+See: [Modifying Default Styles](/docs/default-styles#modifying-default-styles).
 
 </section>
 

--- a/apps/docs/src/content/docs/default-styles/components.mdx
+++ b/apps/docs/src/content/docs/default-styles/components.mdx
@@ -1,5 +1,9 @@
 ---
-title: "components.css"
+title: "Components Stylesheet"
+description:
+  "Component classes stylesheet. Default reusable components like container and
+  screen-reader."
+keywords: ["components.css", "component styles", "default components"]
 ---
 
 # components.css

--- a/apps/docs/src/content/docs/default-styles/index.mdx
+++ b/apps/docs/src/content/docs/default-styles/index.mdx
@@ -1,5 +1,9 @@
 ---
-title: "Default Styles Overview"
+title: "Default Styles in Shilp CSS"
+description:
+  "Explore default styles included with Shilp CSS. Browser resets, colors,
+  variables, and component classes."
+keywords: ["default styles", "browser reset", "color variables", "base styles"]
 ---
 
 # Default Styles Overview

--- a/apps/docs/src/content/docs/default-styles/reset.mdx
+++ b/apps/docs/src/content/docs/default-styles/reset.mdx
@@ -309,8 +309,7 @@ Example:
 Since this file contains only normal CSS rules, it can be **modified or replaced
 entirely** if needed.
 
-See:
-[Modifying Default Styles](/docs/default-styles/overview#modifying-default-styles)
+See: [Modifying Default Styles](/docs/default-styles#modifying-default-styles)
 
 </section>
 

--- a/apps/docs/src/content/docs/default-styles/reset.mdx
+++ b/apps/docs/src/content/docs/default-styles/reset.mdx
@@ -1,5 +1,9 @@
 ---
-title: "reset.css"
+title: "Reset Stylesheet - Browser Defaults"
+description:
+  "Browser reset stylesheet. Normalize element styles across browsers for
+  consistent baseline."
+keywords: ["reset.css", "browser reset", "CSS reset", "normalization"]
 ---
 
 # reset.css

--- a/apps/docs/src/content/docs/default-styles/variables.mdx
+++ b/apps/docs/src/content/docs/default-styles/variables.mdx
@@ -107,7 +107,7 @@ Each system is documented in detail in the **properties documentation**.
 | Typography      | Composes `font-size` using `clamp` to maintain consistent typography.                                    | [Font Size](/docs/properties/text/size)                    |
 | Font Family     | Composes `font-family` using variables to ensure fallback fonts always exist, even when user fonts fail. | [Font Family](/docs/properties/text/family)                |
 | Border Radius   | Componses `border-radius` using single base variable with `calc` to derive mutiple radius sizes          | [Border Radius](/docs/properties/border/rounded)           |
-| Transform       | Composes `transform` using translate, scale, rotate, etc operations.                                     | [Transform](/docs/proeprties/adjust)                       |
+| Transform       | Composes `transform` using translate, scale, rotate, etc operations.                                     | [Transform](/docs/properties/adjust)                       |
 | Box Shadow      | Composes `box-shadow` using size, color, and inset.                                                      | [Box Shadow](/docs/properties/layout/shadow)               |
 | Text Shadow     | Composes `text-shadow` using size and color.                                                             | [Text Shadow](/docs/properties/text/shadow)                |
 | Drop Shadow     | Composes `filter` based `drop-shadow` using size and color.                                              | [Drop Shadow](/docs/properties/filter/shadow)              |
@@ -289,8 +289,7 @@ html,
 Because components and utilities rely on variables, the entire UI will update
 automatically.
 
-See:
-[Modifying Default Styles](/docs/default-styles/overview#modifying-default-styles).
+See: [Modifying Default Styles](/docs/default-styles#modifying-default-styles).
 
 </section>
 

--- a/apps/docs/src/content/docs/default-styles/variables.mdx
+++ b/apps/docs/src/content/docs/default-styles/variables.mdx
@@ -1,5 +1,10 @@
 ---
-title: "variables.css"
+title: "Variables Stylesheet - Utility State"
+description:
+  "Core CSS variables stylesheet. Base and composed variables used by Shilp CSS
+  utilities."
+keywords:
+  ["variables.css", "CSS variables", "state variables", "utility variables"]
 ---
 
 # variables.css

--- a/apps/docs/src/content/docs/life-cycle/index.mdx
+++ b/apps/docs/src/content/docs/life-cycle/index.mdx
@@ -1,5 +1,10 @@
 ---
-title: "Life Cycle's Overview"
+title: "Shilp CSS Processing Life Cycle"
+description:
+  "Understand Shilp CSS processing stages: pre-processing, processing, purging,
+  and transpiling."
+keywords:
+  ["life cycle", "processing stages", "build process", "CSS transformation"]
 ---
 
 # Life Cycle's Overview

--- a/apps/docs/src/content/docs/life-cycle/pre-processing.mdx
+++ b/apps/docs/src/content/docs/life-cycle/pre-processing.mdx
@@ -1,5 +1,10 @@
 ---
-title: "Pre-processing"
+title: "Pre-processing Stage"
+description:
+  "Learn about Shilp CSS pre-processing stage. Configuration preparation and
+  initial CSS parsing."
+keywords:
+  ["pre-processing", "build stage", "configuration processing", "initial stage"]
 ---
 
 # Pre-processing

--- a/apps/docs/src/content/docs/life-cycle/processing.mdx
+++ b/apps/docs/src/content/docs/life-cycle/processing.mdx
@@ -1,5 +1,10 @@
 ---
-title: "Processing"
+title: "Processing Stage"
+description:
+  "Explore Shilp CSS processing stage. Intent parsing and CSS generation from
+  intent syntax."
+keywords:
+  ["processing", "intent parsing", "CSS generation", "intent resolution"]
 ---
 
 # Processing

--- a/apps/docs/src/content/docs/life-cycle/purging.mdx
+++ b/apps/docs/src/content/docs/life-cycle/purging.mdx
@@ -1,5 +1,9 @@
 ---
-title: "Purging"
+title: "Purging Stage - Unused CSS Removal"
+description:
+  "Understand CSS purging in Shilp CSS. Remove unused styles during build using
+  PurgeCSS integration."
+keywords: ["purging", "unused CSS", "PurgeCSS", "build optimization"]
 ---
 
 # Purging

--- a/apps/docs/src/content/docs/life-cycle/transpiling.mdx
+++ b/apps/docs/src/content/docs/life-cycle/transpiling.mdx
@@ -1,5 +1,10 @@
 ---
-title: "Transpiling"
+title: "Transpiling Stage - CSS Optimization"
+description:
+  "Learn CSS transpiling in Shilp CSS. Modern CSS features, vendor prefixes, and
+  browser compatibility."
+keywords:
+  ["transpiling", "CSS optimization", "Lightning CSS", "vendor prefixes"]
 ---
 
 # Transpiling

--- a/apps/docs/src/content/docs/mixins/aria.mdx
+++ b/apps/docs/src/content/docs/mixins/aria.mdx
@@ -1,5 +1,8 @@
 ---
-title: "@aria Mixin"
+title: "@aria Mixin for Accessibility"
+description:
+  "Use @aria mixin for ARIA attribute selectors in Shilp CSS styling."
+keywords: ["@aria", "ARIA", "accessibility mixin", "attribute selector"]
 ---
 
 # @aria Mixin

--- a/apps/docs/src/content/docs/mixins/childs.mdx
+++ b/apps/docs/src/content/docs/mixins/childs.mdx
@@ -1,5 +1,7 @@
 ---
-title: "@childs Mixin"
+title: "@childs Mixin - Child Element Selector"
+description: "Use @childs mixin to style direct child elements in Shilp CSS."
+keywords: ["@childs", "child selector", "child elements", "structural selector"]
 ---
 
 # @childs Mixin

--- a/apps/docs/src/content/docs/mixins/data.mdx
+++ b/apps/docs/src/content/docs/mixins/data.mdx
@@ -1,5 +1,8 @@
 ---
-title: "@data Mixin"
+title: "@data Mixin - Data Attributes"
+description:
+  "Use @data mixin for data attribute selectors in conditional styling."
+keywords: ["@data", "data attributes", "conditional styling", "mixin variants"]
 ---
 
 # @data Mixin

--- a/apps/docs/src/content/docs/mixins/env.mdx
+++ b/apps/docs/src/content/docs/mixins/env.mdx
@@ -1,5 +1,7 @@
 ---
-title: "@env Mixin"
+title: "@env Mixin - Environment Queries"
+description: "Use @env mixin for CSS environment variable queries in Shilp CSS."
+keywords: ["@env", "environment", "CSS environment", "viewport queries"]
 ---
 
 # @env Mixin

--- a/apps/docs/src/content/docs/mixins/form.mdx
+++ b/apps/docs/src/content/docs/mixins/form.mdx
@@ -1,5 +1,8 @@
 ---
-title: "@form Mixin"
+title: "@form Mixin - Form States"
+description:
+  "Use @form mixin for form element states and conditions in Shilp CSS."
+keywords: ["@form", "form mixin", "form states", "input states"]
 ---
 
 # @form Mixin

--- a/apps/docs/src/content/docs/mixins/index.mdx
+++ b/apps/docs/src/content/docs/mixins/index.mdx
@@ -1,5 +1,9 @@
 ---
-title: "Mixins Overview"
+title: "Mixins and Stateful Intents"
+description:
+  "Learn Shilp CSS mixins. Conditional styling with states, themes, breakpoints,
+  and custom conditions."
+keywords: ["mixins", "stateful intents", "conditional styling", "responsive"]
 ---
 
 # Mixins Overview

--- a/apps/docs/src/content/docs/mixins/match.mdx
+++ b/apps/docs/src/content/docs/mixins/match.mdx
@@ -1,5 +1,10 @@
 ---
-title: "@match Mixin"
+title: "@match Mixin - Selector Matching"
+description:
+  "Use @match mixin for complex selector patterns in Shilp CSS conditional
+  styling."
+keywords:
+  ["@match", "selector matching", "pattern matching", "custom selectors"]
 ---
 
 # @match Mixin

--- a/apps/docs/src/content/docs/mixins/motion.mdx
+++ b/apps/docs/src/content/docs/mixins/motion.mdx
@@ -1,5 +1,9 @@
 ---
-title: "@motion Mixin"
+title: "@motion Mixin - Prefers Reduced Motion"
+description:
+  "Use @motion mixin for respecting user motion preferences in animation styles."
+keywords:
+  ["@motion", "prefers-reduced-motion", "accessibility", "animation", "motion"]
 ---
 
 # @motion Mixin

--- a/apps/docs/src/content/docs/mixins/screen.mdx
+++ b/apps/docs/src/content/docs/mixins/screen.mdx
@@ -1,5 +1,9 @@
 ---
-title: "@screen Mixin"
+title: "@screen Mixin - Responsive Breakpoints"
+description:
+  "Use @screen mixin for responsive breakpoints and media queries in Shilp CSS."
+keywords:
+  ["@screen", "responsive", "breakpoints", "media queries", "mobile-first"]
 ---
 
 # @screen Mixin

--- a/apps/docs/src/content/docs/mixins/self.mdx
+++ b/apps/docs/src/content/docs/mixins/self.mdx
@@ -1,5 +1,8 @@
 ---
-title: "@self Mixin"
+title: "@self Mixin - Element Self Selector"
+description:
+  "Use @self mixin to apply styles to the element itself with conditions."
+keywords: ["@self", "self selector", "element selector", "conditional styling"]
 ---
 
 # @self Mixin

--- a/apps/docs/src/content/docs/mixins/siblings.mdx
+++ b/apps/docs/src/content/docs/mixins/siblings.mdx
@@ -1,5 +1,9 @@
 ---
-title: "@siblings Mixin"
+title: "@siblings Mixin - Sibling Elements"
+description:
+  "Use @siblings mixin to style sibling elements based on conditions."
+keywords:
+  ["@siblings", "sibling selector", "structural selector", "related elements"]
 ---
 
 # @siblings Mixin

--- a/apps/docs/src/content/docs/mixins/state.mdx
+++ b/apps/docs/src/content/docs/mixins/state.mdx
@@ -1,5 +1,9 @@
 ---
-title: "@state Mixin"
+title: "@state Mixin - UI States"
+description:
+  "Use @state mixin for hover, focus, active, disabled and other interactive
+  states."
+keywords: ["@state", "UI states", "hover", "focus", "active", "disabled"]
 ---
 
 # @state Mixin

--- a/apps/docs/src/content/docs/mixins/text.mdx
+++ b/apps/docs/src/content/docs/mixins/text.mdx
@@ -1,5 +1,7 @@
 ---
-title: "@text Mixin"
+title: "@text Mixin - Text Conditions"
+description: "Use @text mixin for text-related conditions and pseudo-selectors."
+keywords: ["@text", "text mixin", "text conditions", "text selectors"]
 ---
 
 # @text Mixin

--- a/apps/docs/src/content/docs/mixins/theme.mdx
+++ b/apps/docs/src/content/docs/mixins/theme.mdx
@@ -1,5 +1,8 @@
 ---
-title: "@theme Mixin"
+title: "@theme Mixin - Theme Variants"
+description:
+  "Use @theme mixin for dark/light mode and custom theme switching in Shilp CSS."
+keywords: ["@theme", "dark mode", "light mode", "theme variants", "theming"]
 ---
 
 # @theme Mixin

--- a/apps/docs/src/content/docs/properties/adjust/backside.mdx
+++ b/apps/docs/src/content/docs/properties/adjust/backside.mdx
@@ -1,5 +1,7 @@
 ---
-title: "backside"
+title: "Backface Visibility | @adjust"
+description: "Control backface visibility for 3D transforms and rotations."
+keywords: ["transform", "3d", "backside", "visibility", "css"]
 ---
 
 # backside

--- a/apps/docs/src/content/docs/properties/adjust/distance.mdx
+++ b/apps/docs/src/content/docs/properties/adjust/distance.mdx
@@ -1,5 +1,7 @@
 ---
-title: "distance"
+title: "Transform Perspective | @adjust"
+description: "Set translation distance for transform positioning and movement."
+keywords: ["transform", "translate", "distance", "positioning", "css"]
 ---
 
 # distance

--- a/apps/docs/src/content/docs/properties/adjust/index.mdx
+++ b/apps/docs/src/content/docs/properties/adjust/index.mdx
@@ -1,5 +1,9 @@
 ---
-title: "Adjust Intent Overview"
+title: "Adjust Intent - Transform Utilities"
+description:
+  "Transform styling with @adjust intent. Control rotation, scaling, skewing,
+  and positioning in Shilp CSS."
+keywords: ["@adjust", "transform", "rotation", "scale", "skew", "position"]
 ---
 
 # Adjust Intent Overview

--- a/apps/docs/src/content/docs/properties/adjust/move.mdx
+++ b/apps/docs/src/content/docs/properties/adjust/move.mdx
@@ -1,5 +1,7 @@
 ---
-title: "move"
+title: "Translation Transform | @adjust"
+description: "Apply translation transforms to move elements on X, Y, Z axes."
+keywords: ["transform", "translate", "move", "positioned", "css"]
 ---
 
 # move

--- a/apps/docs/src/content/docs/properties/adjust/origin.mdx
+++ b/apps/docs/src/content/docs/properties/adjust/origin.mdx
@@ -1,5 +1,7 @@
 ---
-title: "origin"
+title: "Transform Origin | @adjust"
+description: "Define the origin point for transformation operations."
+keywords: ["transform", "origin", "transform-origin", "pivot", "css"]
 ---
 
 # origin

--- a/apps/docs/src/content/docs/properties/adjust/preset.mdx
+++ b/apps/docs/src/content/docs/properties/adjust/preset.mdx
@@ -1,5 +1,7 @@
 ---
-title: "preset"
+title: "Transform Presets | @adjust"
+description: "Use preset transformation combinations for common effects."
+keywords: ["transform", "preset", "template", "effects", "css"]
 ---
 
 # preset

--- a/apps/docs/src/content/docs/properties/adjust/rotate.mdx
+++ b/apps/docs/src/content/docs/properties/adjust/rotate.mdx
@@ -1,5 +1,7 @@
 ---
-title: "rotate"
+title: "Rotation Transform | @adjust"
+description: "Apply rotation transforms to elements in 2D or 3D space."
+keywords: ["transform", "rotate", "rotation", "3d", "css"]
 ---
 
 # rotate

--- a/apps/docs/src/content/docs/properties/adjust/scale.mdx
+++ b/apps/docs/src/content/docs/properties/adjust/scale.mdx
@@ -1,5 +1,7 @@
 ---
-title: "scale"
+title: "Scale Transform | @adjust"
+description: "Scale elements larger or smaller using transform properties."
+keywords: ["transform", "scale", "zoom", "size", "css"]
 ---
 
 # scale

--- a/apps/docs/src/content/docs/properties/adjust/shape.mdx
+++ b/apps/docs/src/content/docs/properties/adjust/shape.mdx
@@ -1,5 +1,7 @@
 ---
-title: "shape"
+title: "Shape and Perspective Transform | @adjust"
+description: "Transform and reshape elements with perspective effects."
+keywords: ["transform", "shape", "perspective", "skew", "css"]
 ---
 
 # shape

--- a/apps/docs/src/content/docs/properties/adjust/skew.mdx
+++ b/apps/docs/src/content/docs/properties/adjust/skew.mdx
@@ -1,5 +1,7 @@
 ---
-title: "skew"
+title: "Skew Transform | @adjust"
+description: "Apply skew transforms to distort elements along axes."
+keywords: ["transform", "skew", "distort", "shear", "css"]
 ---
 
 # skew

--- a/apps/docs/src/content/docs/properties/animate/delay.mdx
+++ b/apps/docs/src/content/docs/properties/animate/delay.mdx
@@ -1,5 +1,7 @@
 ---
-title: "delay"
+title: "Animation Delay | @animate"
+description: "Control animation start delay timing in milliseconds."
+keywords: ["animation", "delay", "timing", "transition", "css"]
 ---
 
 # delay

--- a/apps/docs/src/content/docs/properties/animate/direction.mdx
+++ b/apps/docs/src/content/docs/properties/animate/direction.mdx
@@ -1,5 +1,7 @@
 ---
-title: "direction"
+title: "Animation Direction | @animate"
+description: "Set animation direction to play forward, reverse, or alternate."
+keywords: ["animation", "direction", "playback", "reverse", "css"]
 ---
 
 # direction

--- a/apps/docs/src/content/docs/properties/animate/duration.mdx
+++ b/apps/docs/src/content/docs/properties/animate/duration.mdx
@@ -1,5 +1,7 @@
 ---
-title: "duration"
+title: "Animation Duration | @animate"
+description: "Configure animation duration timing in seconds or milliseconds."
+keywords: ["animation", "duration", "timing", "length", "css"]
 ---
 
 # duration

--- a/apps/docs/src/content/docs/properties/animate/enter.mdx
+++ b/apps/docs/src/content/docs/properties/animate/enter.mdx
@@ -1,5 +1,7 @@
 ---
-title: "enter"
+title: "Entry Animation | @animate"
+description: "Define entry animations for elements appearing on screen."
+keywords: ["animation", "enter", "entrance", "appear", "css"]
 ---
 
 # enter

--- a/apps/docs/src/content/docs/properties/animate/exit.mdx
+++ b/apps/docs/src/content/docs/properties/animate/exit.mdx
@@ -1,5 +1,7 @@
 ---
-title: "exit"
+title: "Exit Animation | @animate"
+description: "Define exit animations for elements leaving the screen."
+keywords: ["animation", "exit", "leave", "disappear", "css"]
 ---
 
 # exit

--- a/apps/docs/src/content/docs/properties/animate/fade.mdx
+++ b/apps/docs/src/content/docs/properties/animate/fade.mdx
@@ -1,5 +1,7 @@
 ---
-title: "fade"
+title: "Fade Animation | @animate"
+description: "Apply fade in or fade out animations to elements."
+keywords: ["animation", "fade", "opacity", "transition", "css"]
 ---
 
 # fade

--- a/apps/docs/src/content/docs/properties/animate/flow.mdx
+++ b/apps/docs/src/content/docs/properties/animate/flow.mdx
@@ -1,5 +1,7 @@
 ---
-title: "flow"
+title: "Animation Flow | @animate"
+description: "Control animation flow and sequence behavior."
+keywords: ["animation", "flow", "sequence", "timing", "css"]
 ---
 
 # flow

--- a/apps/docs/src/content/docs/properties/animate/index.mdx
+++ b/apps/docs/src/content/docs/properties/animate/index.mdx
@@ -1,5 +1,10 @@
 ---
-title: "Animate Intent Overview"
+title: "Animate Intent - Animation Utilities"
+description:
+  "Animation styling with @animate intent. Control animation properties, delays,
+  durations, and presets."
+keywords:
+  ["@animate", "animation", "keyframes", "transitions", "duration", "delay"]
 ---
 
 # Animate Intent Overview

--- a/apps/docs/src/content/docs/properties/animate/loop.mdx
+++ b/apps/docs/src/content/docs/properties/animate/loop.mdx
@@ -1,5 +1,7 @@
 ---
-title: "loop"
+title: "Animation Loop | @animate"
+description: "Configure animation loop behavior and iteration count."
+keywords: ["animation", "loop", "repeat", "iterations", "css"]
 ---
 
 # loop

--- a/apps/docs/src/content/docs/properties/animate/mode.mdx
+++ b/apps/docs/src/content/docs/properties/animate/mode.mdx
@@ -1,5 +1,7 @@
 ---
-title: "mode"
+title: "Animation Fill Mode | @animate"
+description: "Set animation mode for fill behavior and end states."
+keywords: ["animation", "mode", "fill", "forward", "css"]
 ---
 
 # mode

--- a/apps/docs/src/content/docs/properties/animate/name.mdx
+++ b/apps/docs/src/content/docs/properties/animate/name.mdx
@@ -1,5 +1,7 @@
 ---
-title: "name"
+title: "Animation Name | @animate"
+description: "Apply named animations by specifying keyframe names."
+keywords: ["animation", "name", "keyframe", "animation-name", "css"]
 ---
 
 # name

--- a/apps/docs/src/content/docs/properties/animate/preset.mdx
+++ b/apps/docs/src/content/docs/properties/animate/preset.mdx
@@ -1,5 +1,7 @@
 ---
-title: "preset"
+title: "Animation Presets | @animate"
+description: "Use preset animation combinations for common effects."
+keywords: ["animation", "preset", "template", "effects", "css"]
 ---
 
 # preset

--- a/apps/docs/src/content/docs/properties/animate/slide.mdx
+++ b/apps/docs/src/content/docs/properties/animate/slide.mdx
@@ -1,5 +1,7 @@
 ---
-title: "slide"
+title: "Slide Animation | @animate"
+description: "Apply slide animations to elements moving across screen."
+keywords: ["animation", "slide", "transform", "movement", "css"]
 ---
 
 # slide

--- a/apps/docs/src/content/docs/properties/animate/spin.mdx
+++ b/apps/docs/src/content/docs/properties/animate/spin.mdx
@@ -1,5 +1,7 @@
 ---
-title: "spin"
+title: "Spin Animation | @animate"
+description: "Apply spinning or rotating animations to elements."
+keywords: ["animation", "spin", "rotate", "circular", "css"]
 ---
 
 # spin

--- a/apps/docs/src/content/docs/properties/animate/state.mdx
+++ b/apps/docs/src/content/docs/properties/animate/state.mdx
@@ -1,5 +1,7 @@
 ---
-title: "state"
+title: "Animation State | @animate"
+description: "Control animation state transitions and pauses."
+keywords: ["animation", "state", "pause", "running", "css"]
 ---
 
 # state

--- a/apps/docs/src/content/docs/properties/animate/zoom.mdx
+++ b/apps/docs/src/content/docs/properties/animate/zoom.mdx
@@ -1,5 +1,7 @@
 ---
-title: "zoom"
+title: "Zoom Animation | @animate"
+description: "Apply zoom in or zoom out animations to elements."
+keywords: ["animation", "zoom", "scale", "magnify", "css"]
 ---
 
 # zoom

--- a/apps/docs/src/content/docs/properties/bg/attachment.mdx
+++ b/apps/docs/src/content/docs/properties/bg/attachment.mdx
@@ -1,5 +1,7 @@
 ---
-title: "attachment"
+title: "Background Attachment | @bg"
+description: "Control background attachment behavior, fixed or scroll."
+keywords: ["background", "attachment", "scroll", "fixed", "css"]
 ---
 
 # attachment

--- a/apps/docs/src/content/docs/properties/bg/blend.mdx
+++ b/apps/docs/src/content/docs/properties/bg/blend.mdx
@@ -1,5 +1,7 @@
 ---
-title: "blend"
+title: "Background Blend Mode | @bg"
+description: "Set background blend mode for layering effects."
+keywords: ["background", "blend", "mix-blend-mode", "compositing", "css"]
 ---
 
 # blend

--- a/apps/docs/src/content/docs/properties/bg/clip.mdx
+++ b/apps/docs/src/content/docs/properties/bg/clip.mdx
@@ -1,5 +1,7 @@
 ---
-title: "clip"
+title: "Background Clip Area | @bg"
+description: "Define background clip area within element."            
+keywords: ["background", "clip", "padding", "border", "css"]
 ---
 
 # clip

--- a/apps/docs/src/content/docs/properties/bg/color.mdx
+++ b/apps/docs/src/content/docs/properties/bg/color.mdx
@@ -1,5 +1,7 @@
 ---
-title: "color"
+title: "Background Color | @bg"
+description: "Apply background color to elements."
+keywords: ["background", "color", "background-color", "styling", "css"]
 ---
 
 # color

--- a/apps/docs/src/content/docs/properties/bg/gradient.mdx
+++ b/apps/docs/src/content/docs/properties/bg/gradient.mdx
@@ -1,5 +1,7 @@
 ---
-title: "gradient"
+title: "Background Gradient | @bg"
+description: "Apply gradient backgrounds with linear or radial patterns."
+keywords: ["background", "gradient", "linear", "radial", "css"]
 ---
 
 # gradient

--- a/apps/docs/src/content/docs/properties/bg/image.mdx
+++ b/apps/docs/src/content/docs/properties/bg/image.mdx
@@ -1,5 +1,7 @@
 ---
-title: "image"
+title: "Background Image | @bg"
+description: "Set background images from URLs or data URIs."
+keywords: ["background", "image", "background-image", "url", "css"]
 ---
 
 # image

--- a/apps/docs/src/content/docs/properties/bg/index.mdx
+++ b/apps/docs/src/content/docs/properties/bg/index.mdx
@@ -1,5 +1,9 @@
 ---
-title: "BG Intent Overview"
+title: "BG Intent - Background Styling"
+description:
+  "Background styling with @bg intent. Control colors, gradients, images, and
+  blend modes."
+keywords: ["@bg", "background", "gradient", "background color", "blend mode"]
 ---
 
 # BG Intent Overview

--- a/apps/docs/src/content/docs/properties/border/color.mdx
+++ b/apps/docs/src/content/docs/properties/border/color.mdx
@@ -1,5 +1,7 @@
 ---
-title: "color"
+title: "Border Color | @border"
+description: "Apply border colors to element borders."
+keywords: ["border", "color", "border-color", "outline", "css"]
 ---
 
 # color

--- a/apps/docs/src/content/docs/properties/border/index.mdx
+++ b/apps/docs/src/content/docs/properties/border/index.mdx
@@ -1,5 +1,9 @@
 ---
-title: "Border Intent Overview"
+title: "Border Intent - Border Styling"
+description:
+  "Border styling with @border intent. Control color, width, radius, and style
+  properties."
+keywords: ["@border", "border", "border-radius", "border-color", "outline"]
 ---
 
 # Border Intent Overview

--- a/apps/docs/src/content/docs/properties/border/rounded.mdx
+++ b/apps/docs/src/content/docs/properties/border/rounded.mdx
@@ -1,5 +1,7 @@
 ---
-title: "rounded"
+title: "Border Radius | @border"
+description: "Set border radius for rounded corners on elements."
+keywords: ["border", "rounded", "border-radius", "corners", "css"]
 ---
 
 # rounded

--- a/apps/docs/src/content/docs/properties/border/style.mdx
+++ b/apps/docs/src/content/docs/properties/border/style.mdx
@@ -1,5 +1,7 @@
 ---
-title: "style"
+title: "Border Style | @border"
+description: "Define border styles like solid, dashed, dotted."
+keywords: ["border", "style", "border-style", "stroke", "css"]
 ---
 
 # style

--- a/apps/docs/src/content/docs/properties/border/thick.mdx
+++ b/apps/docs/src/content/docs/properties/border/thick.mdx
@@ -1,5 +1,7 @@
 ---
-title: "thick"
+title: "Border Width | @border"
+description: "Control border width properties for styling."
+keywords: ["border", "thick", "border-width", "width", "css"]
 ---
 
 # thick

--- a/apps/docs/src/content/docs/properties/filter/backdrop-blur.mdx
+++ b/apps/docs/src/content/docs/properties/filter/backdrop-blur.mdx
@@ -1,5 +1,7 @@
 ---
-title: "backdrop blur"
+title: "Backdrop Blur Filter | @filter"
+description: "Apply backdrop blur filter effect to elements."
+keywords: ["filter", "backdrop", "blur", "effect", "css"]
 ---
 
 # backdrop blur

--- a/apps/docs/src/content/docs/properties/filter/backdrop-bright.mdx
+++ b/apps/docs/src/content/docs/properties/filter/backdrop-bright.mdx
@@ -1,5 +1,7 @@
 ---
-title: "backdrop bright"
+title: "Backdrop Brightness Filter | @filter"
+description: "Adjust backdrop brightness filter values."
+keywords: ["filter", "backdrop", "brightness", "effect", "css"]
 ---
 
 # backdrop bright

--- a/apps/docs/src/content/docs/properties/filter/backdrop-contrast.mdx
+++ b/apps/docs/src/content/docs/properties/filter/backdrop-contrast.mdx
@@ -1,5 +1,7 @@
 ---
-title: "backdrop contrast"
+title: "Backdrop Contrast Filter | @filter"
+description: "Control backdrop contrast filter effect."
+keywords: ["filter", "backdrop", "contrast", "effect", "css"]
 ---
 
 # backdrop contrast

--- a/apps/docs/src/content/docs/properties/filter/backdrop-gray.mdx
+++ b/apps/docs/src/content/docs/properties/filter/backdrop-gray.mdx
@@ -1,5 +1,7 @@
 ---
-title: "backdrop gray"
+title: "Backdrop Grayscale Filter | @filter"
+description: "Apply backdrop grayscale filter to elements."
+keywords: ["filter", "backdrop", "grayscale", "effect", "css"]
 ---
 
 # backdrop gray

--- a/apps/docs/src/content/docs/properties/filter/backdrop-hue.mdx
+++ b/apps/docs/src/content/docs/properties/filter/backdrop-hue.mdx
@@ -1,5 +1,7 @@
 ---
-title: "backdrop hue"
+title: "Backdrop Hue Rotation Filter | @filter"
+description: "Adjust backdrop hue rotation filter values."
+keywords: ["filter", "backdrop", "hue", "color", "css"]
 ---
 
 # backdrop hue

--- a/apps/docs/src/content/docs/properties/filter/backdrop-invert.mdx
+++ b/apps/docs/src/content/docs/properties/filter/backdrop-invert.mdx
@@ -1,5 +1,7 @@
 ---
-title: "backdrop invert"
+title: "Backdrop Invert Filter | @filter"
+description: "Invert backdrop colors with filter effect."
+keywords: ["filter", "backdrop", "invert", "color", "css"]
 ---
 
 # backdrop invert

--- a/apps/docs/src/content/docs/properties/filter/backdrop-opacity.mdx
+++ b/apps/docs/src/content/docs/properties/filter/backdrop-opacity.mdx
@@ -1,5 +1,7 @@
 ---
-title: "backdrop opacity"
+title: "Backdrop Opacity Filter | @filter"
+description: "Control backdrop opacity filter effect."
+keywords: ["filter", "backdrop", "opacity", "transparency", "css"]
 ---
 
 # backdrop opacity

--- a/apps/docs/src/content/docs/properties/filter/backdrop-saturate.mdx
+++ b/apps/docs/src/content/docs/properties/filter/backdrop-saturate.mdx
@@ -1,5 +1,7 @@
 ---
-title: "backdrop saturate"
+title: "Backdrop Saturate Filter | @filter"
+description: "Adjust backdrop saturation filter values."
+keywords: ["filter", "backdrop", "saturate", "color", "css"]
 ---
 
 # backdrop saturate

--- a/apps/docs/src/content/docs/properties/filter/backdrop-sepia.mdx
+++ b/apps/docs/src/content/docs/properties/filter/backdrop-sepia.mdx
@@ -1,5 +1,7 @@
 ---
-title: "backdrop sepia"
+title: "Backdrop Sepia Filter | @filter"
+description: "Apply backdrop sepia tone filter effect."
+keywords: ["filter", "backdrop", "sepia", "tone", "css"]
 ---
 
 # backdrop sepia

--- a/apps/docs/src/content/docs/properties/filter/backdrop-shadow.mdx
+++ b/apps/docs/src/content/docs/properties/filter/backdrop-shadow.mdx
@@ -1,5 +1,7 @@
 ---
-title: "backdrop shadow"
+title: "Backdrop Shadow Filter | @filter"
+description: "Add backdrop shadow filter effects."
+keywords: ["filter", "backdrop", "shadow", "depth", "css"]
 ---
 
 # backdrop shadow

--- a/apps/docs/src/content/docs/properties/filter/backdrop.mdx
+++ b/apps/docs/src/content/docs/properties/filter/backdrop.mdx
@@ -1,5 +1,7 @@
 ---
-title: "backdrop"
+title: "Backdrop Filter | @filter"
+description: "Apply backdrop filter effects to elements."
+keywords: ["filter", "backdrop", "effect", "visual", "css"]
 ---
 
 # backdrop

--- a/apps/docs/src/content/docs/properties/filter/blur.mdx
+++ b/apps/docs/src/content/docs/properties/filter/blur.mdx
@@ -1,5 +1,7 @@
 ---
-title: "blur"
+title: "Blur Filter | @filter"
+description: "Apply blur filter effect to element."
+keywords: ["filter", "blur", "effect", "visual", "css"]
 ---
 
 # blur

--- a/apps/docs/src/content/docs/properties/filter/bright.mdx
+++ b/apps/docs/src/content/docs/properties/filter/bright.mdx
@@ -1,5 +1,7 @@
 ---
-title: "brightness"
+title: "Brightness Filter | @filter"
+description: "Adjust brightness filter effect on elements."
+keywords: ["filter", "brightness", "effect", "visual", "css"]
 ---
 
 # brightness

--- a/apps/docs/src/content/docs/properties/filter/contrast.mdx
+++ b/apps/docs/src/content/docs/properties/filter/contrast.mdx
@@ -1,5 +1,7 @@
 ---
-title: "contrast"
+title: "Contrast Filter | @filter"
+description: "Control contrast filter effect on elements."
+keywords: ["filter", "contrast", "effect", "visual", "css"]
 ---
 
 # contrast

--- a/apps/docs/src/content/docs/properties/filter/gray.mdx
+++ b/apps/docs/src/content/docs/properties/filter/gray.mdx
@@ -1,5 +1,7 @@
 ---
-title: "gray"
+title: "Grayscale Filter | @filter"
+description: "Apply grayscale filter to convert colors to gray."
+keywords: ["filter", "grayscale", "effect", "color", "css"]
 ---
 
 # gray

--- a/apps/docs/src/content/docs/properties/filter/hue.mdx
+++ b/apps/docs/src/content/docs/properties/filter/hue.mdx
@@ -1,5 +1,7 @@
 ---
-title: "hue"
+title: "Hue Rotation | @filter"
+description: "Adjust hue rotation filter on elements."
+keywords: ["filter", "hue", "color", "rotation", "css"]
 ---
 
 # hue

--- a/apps/docs/src/content/docs/properties/filter/index.mdx
+++ b/apps/docs/src/content/docs/properties/filter/index.mdx
@@ -1,5 +1,10 @@
 ---
-title: "Filter Intent Overview"
+title: "Filter Intent - Visual Effects"
+description:
+  "Visual effects with @filter intent. Blur, brightness, contrast, grayscale,
+  and backdrop filters."
+keywords:
+  ["@filter", "filter", "Visual effects", "blur", "backdrop", "brightness"]
 ---
 
 # Filter Intent Overview

--- a/apps/docs/src/content/docs/properties/filter/index.mdx
+++ b/apps/docs/src/content/docs/properties/filter/index.mdx
@@ -14,27 +14,27 @@ CSS properties.
 
 Utilities available in `@filter` intent are listed below.
 
-| Utility               | Description                  | Documentation                                                      |
-| --------------------- | ---------------------------- | ------------------------------------------------------------------ |
-| `blur-*`              | blur filter                  | [blur](/docs/properties/filter/blur)                               |
-| `bright-*`            | brightness filter            | [brightness](/docs/properties/filter/bright)                       |
-| `contrast-*`          | contrast filter              | [contrast](/docs/properties/filter/contrast)                       |
-| `gray-*`              | grayscale filter             | [grayscale](/docs/properties/filter/grayscale)                     |
-| `hue-*`               | hue rotate filter            | [hue](/docs/properties/filter/hue)                                 |
-| `invert-*`            | invert filter                | [invert](/docs/properties/filter/invert)                           |
-| `opacity-*`           | opacity filter               | [opacity](/docs/properties/filter/opacity)                         |
-| `saturate-*`          | saturatation filter          | [saturation](/docs/properties/filter/saturation)                   |
-| `sepia-*`             | sepia filter                 | [sepia](/docs/properties/filter/sepia)                             |
-| `shadow-*`            | drop shadow filter           | [shadow](/docs/properties/filter/shadow)                           |
-| `preset-*`            | `filter` property            | [preset](/docs/properties/filter/preset)                           |
-| `backdrop-*`          | `backdrop-filter` property   | [backdrop](/docs/properties/filter/backdrop)                       |
-| `backdrop-blur-*`     | blur backdrop filter         | [backdrop blur](/docs/properties/filter/backdrop-blur)             |
-| `backdrop-bright-*`   | brightness backdrop filter   | [backdrop bright](/docs/properties/filter/backdrop-bright)         |
-| `backdrop-contrast-*` | contrast backdrop filter     | [backdrop contrast](/docs/properties/filter/backdrop-contrast)     |
-| `backdrop-gray-*`     | grayscale backdrop filter    | [backdrop gray](/docs/properties/filter/backdrop-gray)             |
-| `backdrop-hue-*`      | rotate hue backdrop filter   | [backdrop hue](/docs/properties/filter/backdrop-hue)               |
-| `backdrop-invert-*`   | invert backdrop filter       | [backdrop invert](/docs/properties/filter/backdrop-invert)         |
-| `backdrop-opacity-*`  | opacity backdrop filter      | [backdrop opacity](/docs/properties/filter/backdrop-opacity)       |
-| `backdrop-saturate-*` | saturatation backdrop filter | [backdrop saturation](/docs/properties/filter/backdrop-saturation) |
-| `backdrop-sepia-*`    | sepia backdrop filter        | [backdrop sepia](/docs/properties/filter/backdrop-sepia)           |
-| `backdrop-shadow-*`   | backdrop shadow filter       | [backdrop shadow](/docs/properties/filter/backdrop-shadow)         |
+| Utility               | Description                  | Documentation                                                    |
+| --------------------- | ---------------------------- | ---------------------------------------------------------------- |
+| `blur-*`              | blur filter                  | [blur](/docs/properties/filter/blur)                             |
+| `bright-*`            | brightness filter            | [brightness](/docs/properties/filter/bright)                     |
+| `contrast-*`          | contrast filter              | [contrast](/docs/properties/filter/contrast)                     |
+| `gray-*`              | grayscale filter             | [grayscale](/docs/properties/filter/gray)                        |
+| `hue-*`               | hue rotate filter            | [hue](/docs/properties/filter/hue)                               |
+| `invert-*`            | invert filter                | [invert](/docs/properties/filter/invert)                         |
+| `opacity-*`           | opacity filter               | [opacity](/docs/properties/filter/opacity)                       |
+| `saturate-*`          | saturatation filter          | [saturation](/docs/properties/filter/saturate)                   |
+| `sepia-*`             | sepia filter                 | [sepia](/docs/properties/filter/sepia)                           |
+| `shadow-*`            | drop shadow filter           | [shadow](/docs/properties/filter/shadow)                         |
+| `preset-*`            | `filter` property            | [preset](/docs/properties/filter/preset)                         |
+| `backdrop-*`          | `backdrop-filter` property   | [backdrop](/docs/properties/filter/backdrop)                     |
+| `backdrop-blur-*`     | blur backdrop filter         | [backdrop blur](/docs/properties/filter/backdrop-blur)           |
+| `backdrop-bright-*`   | brightness backdrop filter   | [backdrop bright](/docs/properties/filter/backdrop-bright)       |
+| `backdrop-contrast-*` | contrast backdrop filter     | [backdrop contrast](/docs/properties/filter/backdrop-contrast)   |
+| `backdrop-gray-*`     | grayscale backdrop filter    | [backdrop gray](/docs/properties/filter/backdrop-gray)           |
+| `backdrop-hue-*`      | rotate hue backdrop filter   | [backdrop hue](/docs/properties/filter/backdrop-hue)             |
+| `backdrop-invert-*`   | invert backdrop filter       | [backdrop invert](/docs/properties/filter/backdrop-invert)       |
+| `backdrop-opacity-*`  | opacity backdrop filter      | [backdrop opacity](/docs/properties/filter/backdrop-opacity)     |
+| `backdrop-saturate-*` | saturatation backdrop filter | [backdrop saturation](/docs/properties/filter/backdrop-saturate) |
+| `backdrop-sepia-*`    | sepia backdrop filter        | [backdrop sepia](/docs/properties/filter/backdrop-sepia)         |
+| `backdrop-shadow-*`   | backdrop shadow filter       | [backdrop shadow](/docs/properties/filter/backdrop-shadow)       |

--- a/apps/docs/src/content/docs/properties/filter/invert.mdx
+++ b/apps/docs/src/content/docs/properties/filter/invert.mdx
@@ -1,5 +1,7 @@
 ---
-title: "invert"
+title: "Invert Filter | @filter"
+description: "Invert colors of element with filter."
+keywords: ["filter", "invert", "color", "effect", "css"]
 ---
 
 # invert

--- a/apps/docs/src/content/docs/properties/filter/opacity.mdx
+++ b/apps/docs/src/content/docs/properties/filter/opacity.mdx
@@ -1,5 +1,7 @@
 ---
-title: "opacity"
+title: "Opacity Filter | @filter"
+description: "Control element opacity filter effect."
+keywords: ["filter", "opacity", "transparency", "effect", "css"]
 ---
 
 # opacity

--- a/apps/docs/src/content/docs/properties/filter/preset.mdx
+++ b/apps/docs/src/content/docs/properties/filter/preset.mdx
@@ -1,5 +1,5 @@
 ---
-title: "preset"
+title: "Filter Presets | @filter"
 ---
 
 # preset

--- a/apps/docs/src/content/docs/properties/filter/saturate.mdx
+++ b/apps/docs/src/content/docs/properties/filter/saturate.mdx
@@ -1,5 +1,7 @@
 ---
-title: "saturate"
+title: "Saturate Filter | @filter"
+description: "Adjust saturation filter on element colors."
+keywords: ["filter", "saturate", "color", "effect", "css"]
 ---
 
 # saturate

--- a/apps/docs/src/content/docs/properties/filter/sepia.mdx
+++ b/apps/docs/src/content/docs/properties/filter/sepia.mdx
@@ -1,5 +1,7 @@
 ---
-title: "sepia"
+title: "Sepia Filter | @filter"
+description: "Apply sepia tone filter effect to elements."
+keywords: ["filter", "sepia", "tone", "effect", "css"]
 ---
 
 # sepia

--- a/apps/docs/src/content/docs/properties/filter/shadow.mdx
+++ b/apps/docs/src/content/docs/properties/filter/shadow.mdx
@@ -1,5 +1,7 @@
 ---
-title: "shadow"
+title: "Shadow Filter | @filter"
+description: "Add shadow filter effects to elements."
+keywords: ["filter", "shadow", "depth", "effect", "css"]
 ---
 
 # shadow

--- a/apps/docs/src/content/docs/properties/flex/base.mdx
+++ b/apps/docs/src/content/docs/properties/flex/base.mdx
@@ -1,5 +1,7 @@
 ---
-title: "base"
+title: "Flex Basis | @flex"
+description: "Set flex-basis sizing for flex items."
+keywords: ["flex", "basis", "sizing", "layout", "css"]
 ---
 
 # base

--- a/apps/docs/src/content/docs/properties/flex/content.mdx
+++ b/apps/docs/src/content/docs/properties/flex/content.mdx
@@ -1,5 +1,7 @@
 ---
-title: "base"
+title: "Flex Content Alignment | @flex"
+description: "Control flex container content alignment."
+keywords: ["flex", "align", "content", "layout", "css"]
 ---
 
 # base

--- a/apps/docs/src/content/docs/properties/flex/flow.mdx
+++ b/apps/docs/src/content/docs/properties/flex/flow.mdx
@@ -1,5 +1,7 @@
 ---
-title: "flow"
+title: "Flex Direction | @flex"
+description: "Define flex layout direction and wrapping."
+keywords: ["flex", "direction", "flow", "layout", "css"]
 ---
 
 # flow

--- a/apps/docs/src/content/docs/properties/flex/grow.mdx
+++ b/apps/docs/src/content/docs/properties/flex/grow.mdx
@@ -1,5 +1,7 @@
 ---
-title: "grow"
+title: "Flex Grow | @flex"
+description: "Set flex grow factor for expanding items."
+keywords: ["flex", "grow", "expand", "layout", "css"]
 ---
 
 # grow

--- a/apps/docs/src/content/docs/properties/flex/index.mdx
+++ b/apps/docs/src/content/docs/properties/flex/index.mdx
@@ -1,5 +1,10 @@
 ---
-title: "Flex Intent Overview"
+title: "Flex Intent - Flexbox Utilities"
+description:
+  "Flexbox styling with @flex intent. Alignment, direction, growth, and flex
+  layout utilities."
+keywords:
+  ["@flex", "flexbox", "flex layout", "alignment", "justify", "align items"]
 ---
 
 # Flex Intent Overview

--- a/apps/docs/src/content/docs/properties/flex/items.mdx
+++ b/apps/docs/src/content/docs/properties/flex/items.mdx
@@ -1,5 +1,7 @@
 ---
-title: "items"
+title: "Flex Items Alignment | @flex"
+description: "Align flex items within container."
+keywords: ["flex", "align", "items", "layout", "css"]
 ---
 
 # items

--- a/apps/docs/src/content/docs/properties/flex/justify.mdx
+++ b/apps/docs/src/content/docs/properties/flex/justify.mdx
@@ -1,5 +1,7 @@
 ---
-title: "justify"
+title: "Flex Justify Content | @flex"
+description: "Justify flex content distribution along main axis."
+keywords: ["flex", "justify", "align", "layout", "css"]
 ---
 
 # justify

--- a/apps/docs/src/content/docs/properties/flex/order.mdx
+++ b/apps/docs/src/content/docs/properties/flex/order.mdx
@@ -1,5 +1,7 @@
 ---
-title: "order"
+title: "Flex Order | @flex"
+description: "Set flex item order within container."
+keywords: ["flex", "order", "sequence", "layout", "css"]
 ---
 
 # order

--- a/apps/docs/src/content/docs/properties/flex/place.mdx
+++ b/apps/docs/src/content/docs/properties/flex/place.mdx
@@ -1,5 +1,7 @@
 ---
-title: "place"
+title: "Flex Place Alignment | @flex"
+description: "Place flex items with combined alignment."
+keywords: ["flex", "place", "align", "layout", "css"]
 ---
 
 # place

--- a/apps/docs/src/content/docs/properties/flex/preset.mdx
+++ b/apps/docs/src/content/docs/properties/flex/preset.mdx
@@ -1,5 +1,7 @@
 ---
-title: "preset"
+title: "Flex Presets | @flex"
+description: "Use preset flexbox layout combinations."
+keywords: ["flex", "preset", "template", "layout", "css"]
 ---
 
 # preset

--- a/apps/docs/src/content/docs/properties/flex/self.mdx
+++ b/apps/docs/src/content/docs/properties/flex/self.mdx
@@ -1,5 +1,7 @@
 ---
-title: "self"
+title: "Flex Self Alignment | @flex"
+description: "Align individual flex item within container."
+keywords: ["flex", "self", "align", "item", "css"]
 ---
 
 # self

--- a/apps/docs/src/content/docs/properties/flex/shrink.mdx
+++ b/apps/docs/src/content/docs/properties/flex/shrink.mdx
@@ -1,5 +1,7 @@
 ---
-title: "shrink"
+title: "Flex Shrink | @flex"
+description: "Control flex shrink factor for items."
+keywords: ["flex", "shrink", "compress", "layout", "css"]
 ---
 
 # shrink

--- a/apps/docs/src/content/docs/properties/flex/wrap.mdx
+++ b/apps/docs/src/content/docs/properties/flex/wrap.mdx
@@ -1,5 +1,7 @@
 ---
-title: "wrap"
+title: "Flex Wrap | @flex"
+description: "Control flex wrapping behavior."
+keywords: ["flex", "wrap", "flow", "layout", "css"]
 ---
 
 # wrap

--- a/apps/docs/src/content/docs/properties/form/accent.mdx
+++ b/apps/docs/src/content/docs/properties/form/accent.mdx
@@ -1,5 +1,7 @@
 ---
-title: "accent color"
+title: "Accent Color | @form"
+description: "Set form control accent color."
+keywords: ["form", "accent", "color", "input", "css"]
 ---
 
 # accent color

--- a/apps/docs/src/content/docs/properties/form/index.mdx
+++ b/apps/docs/src/content/docs/properties/form/index.mdx
@@ -1,5 +1,10 @@
 ---
-title: "Form Intent Overview"
+title: "Form Intent - Form Control Styling"
+description:
+  "Form control styling with @form intent. Input appearance, accent colors, and
+  form element styling."
+keywords:
+  ["@form", "form controls", "input", "form styling", "checkbox", "radio"]
 ---
 
 # Form Intent Overview

--- a/apps/docs/src/content/docs/properties/form/resize.mdx
+++ b/apps/docs/src/content/docs/properties/form/resize.mdx
@@ -1,5 +1,7 @@
 ---
-title: "resize"
+title: "Resize Behavior | @form"
+description: "Control textarea and element resize behavior."
+keywords: ["form", "resize", "textarea", "control", "css"]
 ---
 
 # resize

--- a/apps/docs/src/content/docs/properties/form/skin.mdx
+++ b/apps/docs/src/content/docs/properties/form/skin.mdx
@@ -1,5 +1,7 @@
 ---
-title: "skin"
+title: "Form Appearance | @form"
+description: "Apply form control appearance and styling."
+keywords: ["form", "skin", "style", "control", "css"]
 ---
 
 # skin

--- a/apps/docs/src/content/docs/properties/grid/col.mdx
+++ b/apps/docs/src/content/docs/properties/grid/col.mdx
@@ -1,5 +1,7 @@
 ---
-title: "col"
+title: "Grid Column Span | @grid"
+description: "Set grid item column span position."
+keywords: ["grid", "column", "col", "layout", "css"]
 ---
 
 # col

--- a/apps/docs/src/content/docs/properties/grid/cols.mdx
+++ b/apps/docs/src/content/docs/properties/grid/cols.mdx
@@ -1,5 +1,7 @@
 ---
-title: "cols"
+title: "Grid Columns Layout | @grid"
+description: "Define grid columns layout structure."
+keywords: ["grid", "columns", "layout", "grid-template", "css"]
 ---
 
 # cols

--- a/apps/docs/src/content/docs/properties/grid/content.mdx
+++ b/apps/docs/src/content/docs/properties/grid/content.mdx
@@ -1,5 +1,7 @@
 ---
-title: "content"
+title: "Grid Content Alignment | @grid"
+description: "Control grid content alignment."
+keywords: ["grid", "align", "content", "layout", "css"]
 ---
 
 # content

--- a/apps/docs/src/content/docs/properties/grid/flow.mdx
+++ b/apps/docs/src/content/docs/properties/grid/flow.mdx
@@ -1,5 +1,7 @@
 ---
-title: "flow"
+title: "Grid Flow | @grid"
+description: "Define grid layout flow direction."
+keywords: ["grid", "flow", "direction", "layout", "css"]
 ---
 
 # flow

--- a/apps/docs/src/content/docs/properties/grid/index.mdx
+++ b/apps/docs/src/content/docs/properties/grid/index.mdx
@@ -1,5 +1,17 @@
 ---
-title: "Grid Intent Overview"
+title: "Grid Intent - CSS Grid Utilities"
+description:
+  "CSS Grid styling with @grid intent. Grid layout, columns, rows, and grid item
+  positioning."
+keywords:
+  [
+    "@grid",
+    "CSS grid",
+    "grid layout",
+    "grid columns",
+    "grid rows",
+    "grid areas",
+  ]
 ---
 
 # Grid Intent Overview

--- a/apps/docs/src/content/docs/properties/grid/items.mdx
+++ b/apps/docs/src/content/docs/properties/grid/items.mdx
@@ -1,5 +1,7 @@
 ---
-title: "items"
+title: "Grid Items Alignment | @grid"
+description: "Align grid items within container."
+keywords: ["grid", "align", "items", "layout", "css"]
 ---
 
 # items

--- a/apps/docs/src/content/docs/properties/grid/justify.mdx
+++ b/apps/docs/src/content/docs/properties/grid/justify.mdx
@@ -1,5 +1,7 @@
 ---
-title: "justify"
+title: "Grid Justify Content | @grid"
+description: "Justify grid content along main axis."
+keywords: ["grid", "justify", "align", "layout", "css"]
 ---
 
 # justify

--- a/apps/docs/src/content/docs/properties/grid/order.mdx
+++ b/apps/docs/src/content/docs/properties/grid/order.mdx
@@ -1,5 +1,7 @@
 ---
-title: "order"
+title: "Grid Order | @grid"
+description: "Set grid item order position."
+keywords: ["grid", "order", "sequence", "layout", "css"]
 ---
 
 # order

--- a/apps/docs/src/content/docs/properties/grid/place.mdx
+++ b/apps/docs/src/content/docs/properties/grid/place.mdx
@@ -1,5 +1,7 @@
 ---
-title: "place"
+title: "Grid Place Alignment | @grid"
+description: "Place grid items with combined alignment."
+keywords: ["grid", "place", "align", "layout", "css"]
 ---
 
 # place

--- a/apps/docs/src/content/docs/properties/grid/preset.mdx
+++ b/apps/docs/src/content/docs/properties/grid/preset.mdx
@@ -1,5 +1,7 @@
 ---
-title: "preset"
+title: "Grid Presets | @grid"
+description: "Use preset grid layout combinations."
+keywords: ["grid", "preset", "template", "layout", "css"]
 ---
 
 # preset

--- a/apps/docs/src/content/docs/properties/grid/row.mdx
+++ b/apps/docs/src/content/docs/properties/grid/row.mdx
@@ -1,5 +1,7 @@
 ---
-title: "row"
+title: "Grid Row Span | @grid"
+description: "Set grid item row span position."
+keywords: ["grid", "row", "span", "layout", "css"]
 ---
 
 # row

--- a/apps/docs/src/content/docs/properties/grid/rows.mdx
+++ b/apps/docs/src/content/docs/properties/grid/rows.mdx
@@ -1,5 +1,7 @@
 ---
-title: "rows"
+title: "Grid Rows Layout | @grid"
+description: "Define grid rows layout structure."
+keywords: ["grid", "rows", "layout", "grid-template", "css"]
 ---
 
 # rows

--- a/apps/docs/src/content/docs/properties/grid/self.mdx
+++ b/apps/docs/src/content/docs/properties/grid/self.mdx
@@ -1,5 +1,7 @@
 ---
-title: "self"
+title: "Grid Self Alignment | @grid"
+description: "Align individual grid item."
+keywords: ["grid", "self", "align", "item", "css"]
 ---
 
 # self

--- a/apps/docs/src/content/docs/properties/index.mdx
+++ b/apps/docs/src/content/docs/properties/index.mdx
@@ -1,5 +1,10 @@
 ---
-title: "Properties Overview"
+title: "Properties and Intent Categories"
+description:
+  "Overview of all Shilp CSS properties grouped into intents. Complete guide to
+  19 style intent categories."
+keywords:
+  ["properties", "intents", "styling categories", "CSS utilities overview"]
 ---
 
 # Properties Overview

--- a/apps/docs/src/content/docs/properties/layout/blend.mdx
+++ b/apps/docs/src/content/docs/properties/layout/blend.mdx
@@ -1,5 +1,7 @@
 ---
-title: "blend"
+title: "Mix Blend Mode | @layout"
+description: "Set mix-blend-mode for element compositing."
+keywords: ["layout", "blend", "mix", "compositing", "css"]
 ---
 
 # blend

--- a/apps/docs/src/content/docs/properties/layout/box.mdx
+++ b/apps/docs/src/content/docs/properties/layout/box.mdx
@@ -1,5 +1,7 @@
 ---
-title: "box"
+title: "Box Sizing | @layout"
+description: "Control box-sizing model for elements."
+keywords: ["layout", "box", "sizing", "model", "css"]
 ---
 
 # box

--- a/apps/docs/src/content/docs/properties/layout/float.mdx
+++ b/apps/docs/src/content/docs/properties/layout/float.mdx
@@ -1,5 +1,7 @@
 ---
-title: "float"
+title: "Float Positioning | @layout"
+description: "Set float positioning for elements."
+keywords: ["layout", "float", "positioning", "flow", "css"]
 ---
 
 # float

--- a/apps/docs/src/content/docs/properties/layout/hide.mdx
+++ b/apps/docs/src/content/docs/properties/layout/hide.mdx
@@ -1,5 +1,7 @@
 ---
-title: "hide"
+title: "Hide Elements | @layout"
+description: "Hide elements from view and layout."
+keywords: ["layout", "hide", "display", "visibility", "css"]
 ---
 
 # hide

--- a/apps/docs/src/content/docs/properties/layout/index.mdx
+++ b/apps/docs/src/content/docs/properties/layout/index.mdx
@@ -1,5 +1,9 @@
 ---
-title: "Layout Intent Overview"
+title: "Layout Intent - Display and Layout"
+description:
+  "Layout styling with @layout intent. Display modes, shadows, overflow, and
+  layout utilities."
+keywords: ["@layout", "display", "layout", "shadow", "overflow", "visibility"]
 ---
 
 # Layout Intent Overview

--- a/apps/docs/src/content/docs/properties/layout/is.mdx
+++ b/apps/docs/src/content/docs/properties/layout/is.mdx
@@ -1,5 +1,7 @@
 ---
-title: "is"
+title: "Display Type | @layout"
+description: "Define element display property type."
+keywords: ["layout", "display", "is", "block", "css"]
 ---
 
 # is

--- a/apps/docs/src/content/docs/properties/layout/isolate.mdx
+++ b/apps/docs/src/content/docs/properties/layout/isolate.mdx
@@ -1,5 +1,7 @@
 ---
-title: "isolate"
+title: "Stacking Context Isolation | @layout"
+description: "Create new stacking context for elements."
+keywords: ["layout", "isolate", "stacking", "context", "css"]
 ---
 
 # isolate

--- a/apps/docs/src/content/docs/properties/layout/layer.mdx
+++ b/apps/docs/src/content/docs/properties/layout/layer.mdx
@@ -1,5 +1,7 @@
 ---
-title: "layer"
+title: "Z Index Layer | @layout"
+description: "Control z-index stacking order."
+keywords: ["layout", "layer", "z-index", "stacking", "css"]
 ---
 
 # layer

--- a/apps/docs/src/content/docs/properties/layout/object.mdx
+++ b/apps/docs/src/content/docs/properties/layout/object.mdx
@@ -1,5 +1,7 @@
 ---
-title: "object"
+title: "Object Fit and Position | @layout"
+description: "Control object-fit and object-position."
+keywords: ["layout", "object", "fit", "position", "css"]
 ---
 
 # object

--- a/apps/docs/src/content/docs/properties/layout/opacity.mdx
+++ b/apps/docs/src/content/docs/properties/layout/opacity.mdx
@@ -1,5 +1,7 @@
 ---
-title: "opacity"
+title: "Element Opacity | @layout"
+description: "Control element opacity and transparency."
+keywords: ["layout", "opacity", "transparency", "alpha", "css"]
 ---
 
 # opacity

--- a/apps/docs/src/content/docs/properties/layout/overflow.mdx
+++ b/apps/docs/src/content/docs/properties/layout/overflow.mdx
@@ -1,5 +1,7 @@
 ---
-title: "overflow"
+title: "Overflow Handling | @layout"
+description: "Handle overflow content display."
+keywords: ["layout", "overflow", "hidden", "scroll", "css"]
 ---
 
 # overflow

--- a/apps/docs/src/content/docs/properties/layout/ratio.mdx
+++ b/apps/docs/src/content/docs/properties/layout/ratio.mdx
@@ -1,5 +1,7 @@
 ---
-title: "ratio"
+title: "Aspect Ratio | @layout"
+description: "Set aspect ratio for elements."
+keywords: ["layout", "ratio", "aspect", "proportion", "css"]
 ---
 
 # ratio

--- a/apps/docs/src/content/docs/properties/layout/shadow.mdx
+++ b/apps/docs/src/content/docs/properties/layout/shadow.mdx
@@ -1,5 +1,7 @@
 ---
-title: "shadow"
+title: "Drop Shadow | @layout"
+description: "Add drop shadow effects to elements."
+keywords: ["layout", "shadow", "depth", "effect", "css"]
 ---
 
 # shadow

--- a/apps/docs/src/content/docs/properties/layout/show.mdx
+++ b/apps/docs/src/content/docs/properties/layout/show.mdx
@@ -1,5 +1,7 @@
 ---
-title: "show"
+title: "Show Elements | @layout"
+description: "Show hidden elements in layout."
+keywords: ["layout", "show", "display", "visibility", "css"]
 ---
 
 # show

--- a/apps/docs/src/content/docs/properties/layout/theme.mdx
+++ b/apps/docs/src/content/docs/properties/layout/theme.mdx
@@ -1,5 +1,7 @@
 ---
-title: "theme"
+title: "Theme Styles | @layout"
+description: "Apply themes to elements."
+keywords: ["layout", "theme", "styling", "color", "css"]
 ---
 
 # theme

--- a/apps/docs/src/content/docs/properties/list/align.mdx
+++ b/apps/docs/src/content/docs/properties/list/align.mdx
@@ -1,5 +1,7 @@
 ---
-title: "align"
+title: "List Marker Alignment | @list"
+description: "Align list markers within lists."
+keywords: ["list", "align", "marker", "positioning", "css"]
 ---
 
 # align

--- a/apps/docs/src/content/docs/properties/list/index.mdx
+++ b/apps/docs/src/content/docs/properties/list/index.mdx
@@ -1,5 +1,9 @@
 ---
-title: "List Intent Overview"
+title: "List Intent - List Styling"
+description:
+  "List styling with @list intent. List markers, styles, and list layout
+  utilities."
+keywords: ["@list", "list", "list style", "list items", "markers"]
 ---
 
 # List Intent Overview

--- a/apps/docs/src/content/docs/properties/list/marker.mdx
+++ b/apps/docs/src/content/docs/properties/list/marker.mdx
@@ -1,5 +1,7 @@
 ---
-title: "marker"
+title: "List Marker Style | @list"
+description: "Style list markers and bullets."
+keywords: ["list", "marker", "bullet", "style", "css"]
 ---
 
 # marker

--- a/apps/docs/src/content/docs/properties/live/caret.mdx
+++ b/apps/docs/src/content/docs/properties/live/caret.mdx
@@ -1,5 +1,7 @@
 ---
-title: "caret"
+title: "Caret Cursor Style | @live"
+description: "Style text input caret cursor."
+keywords: ["live", "caret", "cursor", "input", "css"]
 ---
 
 # caret

--- a/apps/docs/src/content/docs/properties/live/cursor.mdx
+++ b/apps/docs/src/content/docs/properties/live/cursor.mdx
@@ -1,5 +1,7 @@
 ---
-title: "cursor"
+title: "Cursor Style | @live"
+description: "Set cursor style on hover."
+keywords: ["live", "cursor", "interaction", "pointer", "css"]
 ---
 
 # cursor

--- a/apps/docs/src/content/docs/properties/live/events.mdx
+++ b/apps/docs/src/content/docs/properties/live/events.mdx
@@ -1,5 +1,7 @@
 ---
-title: "events"
+title: "Event Handling | @live"
+description: "Control user interaction event handling."
+keywords: ["live", "events", "interaction", "pointer", "css"]
 ---
 
 # events

--- a/apps/docs/src/content/docs/properties/live/index.mdx
+++ b/apps/docs/src/content/docs/properties/live/index.mdx
@@ -1,5 +1,10 @@
 ---
-title: "Live Intent Overview"
+title: "Live Intent - User Interaction"
+description:
+  "User interaction styling with @live intent. Cursor, user-select, and
+  interaction utilities."
+keywords:
+  ["@live", "user interaction", "cursor", "user-select", "pointer events"]
 ---
 
 # Live Intent Overview

--- a/apps/docs/src/content/docs/properties/live/outline.mdx
+++ b/apps/docs/src/content/docs/properties/live/outline.mdx
@@ -1,5 +1,7 @@
 ---
-title: "outline"
+title: "Outline Style | @live"
+description: "Set element outline styling."
+keywords: ["live", "outline", "border", "focus", "css"]
 ---
 
 # outline

--- a/apps/docs/src/content/docs/properties/live/scroll-margin.mdx
+++ b/apps/docs/src/content/docs/properties/live/scroll-margin.mdx
@@ -1,5 +1,7 @@
 ---
-title: "scroll margin"
+title: "Scroll Margin | @live"
+description: "Set scroll margin spacing around elements."
+keywords: ["live", "scroll", "margin", "spacing", "css"]
 ---
 
 # scroll margin

--- a/apps/docs/src/content/docs/properties/live/scroll-padding.mdx
+++ b/apps/docs/src/content/docs/properties/live/scroll-padding.mdx
@@ -1,5 +1,7 @@
 ---
-title: "scroll padding"
+title: "Scroll Padding | @live"
+description: "Set scroll padding spacing around elements."
+keywords: ["live", "scroll", "padding", "spacing", "css"]
 ---
 
 # scroll padding

--- a/apps/docs/src/content/docs/properties/live/scroll-snap.mdx
+++ b/apps/docs/src/content/docs/properties/live/scroll-snap.mdx
@@ -1,5 +1,7 @@
 ---
-title: "scroll snap"
+title: "Scroll Snap | @live"
+description: "Enable scroll snap behavior on containers."
+keywords: ["live", "scroll", "snap", "behavior", "css"]
 ---
 
 # scroll snap

--- a/apps/docs/src/content/docs/properties/live/scroll.mdx
+++ b/apps/docs/src/content/docs/properties/live/scroll.mdx
@@ -1,5 +1,7 @@
 ---
-title: "scroll"
+title: "Scroll Behavior | @live"
+description: "Control scroll behavior and properties."
+keywords: ["live", "scroll", "behavior", "smooth", "css"]
 ---
 
 # scroll

--- a/apps/docs/src/content/docs/properties/live/select.mdx
+++ b/apps/docs/src/content/docs/properties/live/select.mdx
@@ -1,5 +1,7 @@
 ---
-title: "select"
+title: "Text Selection | @live"
+description: "Control text selection behavior."
+keywords: ["live", "select", "selection", "user", "css"]
 ---
 
 # select

--- a/apps/docs/src/content/docs/properties/live/touch.mdx
+++ b/apps/docs/src/content/docs/properties/live/touch.mdx
@@ -1,5 +1,7 @@
 ---
-title: "touch"
+title: "Touch Interaction | @live"
+description: "Control touch interaction behavior."
+keywords: ["live", "touch", "interaction", "mobile", "css"]
 ---
 
 # touch

--- a/apps/docs/src/content/docs/properties/mask/clip.mdx
+++ b/apps/docs/src/content/docs/properties/mask/clip.mdx
@@ -1,5 +1,7 @@
 ---
-title: "clip"
+title: "Mask Clip | @mask"
+description: "Define mask clip area within element."
+keywords: ["mask", "clip", "clipping", "area", "css"]
 ---
 
 # clip

--- a/apps/docs/src/content/docs/properties/mask/combine.mdx
+++ b/apps/docs/src/content/docs/properties/mask/combine.mdx
@@ -1,5 +1,7 @@
 ---
-title: "combine"
+title: "Mask Combination | @mask"
+description: "Combine multiple masks on element."
+keywords: ["mask", "combine", "multiple", "layer", "css"]
 ---
 
 # combine

--- a/apps/docs/src/content/docs/properties/mask/gradient.mdx
+++ b/apps/docs/src/content/docs/properties/mask/gradient.mdx
@@ -1,5 +1,7 @@
 ---
-title: "gradient"
+title: "Gradient Mask | @mask"
+description: "Apply gradient masks to elements."
+keywords: ["mask", "gradient", "linear", "radial", "css"]
 ---
 
 # gradient

--- a/apps/docs/src/content/docs/properties/mask/image.mdx
+++ b/apps/docs/src/content/docs/properties/mask/image.mdx
@@ -1,5 +1,7 @@
 ---
-title: "img"
+title: "Mask Image | @mask"
+description: "Set mask images from URLs."
+keywords: ["mask", "image", "mask-image", "url", "css"]
 ---
 
 # img

--- a/apps/docs/src/content/docs/properties/mask/index.mdx
+++ b/apps/docs/src/content/docs/properties/mask/index.mdx
@@ -1,5 +1,9 @@
 ---
-title: "Mask Intent Overview"
+title: "Mask Intent - Masking Utilities"
+description:
+  "Element masking with @mask intent. Clip-path, mask-image, and mask
+  properties."
+keywords: ["@mask", "mask", "clip-path", "masking", "element clipping"]
 ---
 
 # Mask Intent Overview

--- a/apps/docs/src/content/docs/properties/mask/mode.mdx
+++ b/apps/docs/src/content/docs/properties/mask/mode.mdx
@@ -1,5 +1,7 @@
 ---
-title: "mode"
+title: "Mask Mode | @mask"
+description: "Set mask blend mode for compositing."
+keywords: ["mask", "mode", "blend", "compositing", "css"]
 ---
 
 # mode

--- a/apps/docs/src/content/docs/properties/mask/origin.mdx
+++ b/apps/docs/src/content/docs/properties/mask/origin.mdx
@@ -1,5 +1,7 @@
 ---
-title: "origin"
+title: "Mask Origin | @mask"
+description: "Set mask origin position."
+keywords: ["mask", "origin", "position", "reference", "css"]
 ---
 
 # origin

--- a/apps/docs/src/content/docs/properties/mask/position.mdx
+++ b/apps/docs/src/content/docs/properties/mask/position.mdx
@@ -1,5 +1,7 @@
 ---
-title: "position"
+title: "Mask Position | @mask"
+description: "Position mask image on element."
+keywords: ["mask", "position", "placement", "offset", "css"]
 ---
 
 # position

--- a/apps/docs/src/content/docs/properties/mask/repeat.mdx
+++ b/apps/docs/src/content/docs/properties/mask/repeat.mdx
@@ -1,5 +1,7 @@
 ---
-title: "repeat"
+title: "Mask Repeat | @mask"
+description: "Control mask image repetition."
+keywords: ["mask", "repeat", "tiling", "pattern", "css"]
 ---
 
 # repeat

--- a/apps/docs/src/content/docs/properties/mask/size.mdx
+++ b/apps/docs/src/content/docs/properties/mask/size.mdx
@@ -1,5 +1,7 @@
 ---
-title: "size"
+title: "Mask Size | @mask"
+description: "Set mask image size."
+keywords: ["mask", "size", "dimension", "width", "css"]
 ---
 
 # size

--- a/apps/docs/src/content/docs/properties/mask/type.mdx
+++ b/apps/docs/src/content/docs/properties/mask/type.mdx
@@ -1,5 +1,7 @@
 ---
-title: "type"
+title: "Mask Type | @mask"
+description: "Define mask type for clipping."
+keywords: ["mask", "type", "clipping", "alpha", "css"]
 ---
 
 # type

--- a/apps/docs/src/content/docs/properties/phase/delay.mdx
+++ b/apps/docs/src/content/docs/properties/phase/delay.mdx
@@ -1,5 +1,7 @@
 ---
-title: "delay"
+title: "Phase Animation Delay | @phase"
+description: "Control phase animation delay timing."
+keywords: ["phase", "delay", "animation", "timing", "css"]
 ---
 
 # delay

--- a/apps/docs/src/content/docs/properties/phase/duration.mdx
+++ b/apps/docs/src/content/docs/properties/phase/duration.mdx
@@ -1,5 +1,7 @@
 ---
-title: "duration"
+title: "Phase Animation Duration | @phase"
+description: "Set phase animation duration."
+keywords: ["phase", "duration", "animation", "timing", "css"]
 ---
 
 # duration

--- a/apps/docs/src/content/docs/properties/phase/flow.mdx
+++ b/apps/docs/src/content/docs/properties/phase/flow.mdx
@@ -1,5 +1,7 @@
 ---
-title: "flow"
+title: "Phase Animation Flow | @phase"
+description: "Control phase animation flow."
+keywords: ["phase", "flow", "animation", "sequence", "css"]
 ---
 
 # flow

--- a/apps/docs/src/content/docs/properties/phase/for.mdx
+++ b/apps/docs/src/content/docs/properties/phase/for.mdx
@@ -1,5 +1,7 @@
 ---
-title: "for"
+title: "Phase Target Selector | @phase"
+description: "Define phase target elements."
+keywords: ["phase", "for", "selector", "target", "css"]
 ---
 
 # for

--- a/apps/docs/src/content/docs/properties/phase/index.mdx
+++ b/apps/docs/src/content/docs/properties/phase/index.mdx
@@ -1,5 +1,9 @@
 ---
-title: "Phase Intent Overview"
+title: "Phase Intent - Transitions"
+description:
+  "Transition styling with @phase intent. Control transitions, timing, and
+  animation properties."
+keywords: ["@phase", "transition", "timing function", "duration", "animation"]
 ---
 
 # Phase Intent Overview

--- a/apps/docs/src/content/docs/properties/phase/preset.mdx
+++ b/apps/docs/src/content/docs/properties/phase/preset.mdx
@@ -1,5 +1,7 @@
 ---
-title: "preset"
+title: "Phase Animation Presets | @phase"
+description: "Use phase animation presets."
+keywords: ["phase", "preset", "template", "animation", "css"]
 ---
 
 # preset

--- a/apps/docs/src/content/docs/properties/position/bottom.mdx
+++ b/apps/docs/src/content/docs/properties/position/bottom.mdx
@@ -1,5 +1,7 @@
 ---
-title: "bottom"
+title: "Bottom Offset | @position"
+description: "Set bottom positioning offset for elements."
+keywords: ["position", "bottom", "offset", "coordinate", "css"]
 ---
 
 # bottom

--- a/apps/docs/src/content/docs/properties/position/index.mdx
+++ b/apps/docs/src/content/docs/properties/position/index.mdx
@@ -1,5 +1,10 @@
 ---
-title: "Position Intent Overview"
+title: "Position Intent - Positioning Utilities"
+description:
+  "Positioning with @position intent. Absolute, relative, fixed, and sticky
+  positioning utilities."
+keywords:
+  ["@position", "positioning", "absolute", "relative", "fixed", "sticky"]
 ---
 
 # Position Intent Overview

--- a/apps/docs/src/content/docs/properties/position/inset.mdx
+++ b/apps/docs/src/content/docs/properties/position/inset.mdx
@@ -1,5 +1,7 @@
 ---
-title: "inset"
+title: "Inset Offsets | @position"
+description: "Set all inset positioning values."
+keywords: ["position", "inset", "offset", "shorthand", "css"]
 ---
 
 # inset

--- a/apps/docs/src/content/docs/properties/position/is.mdx
+++ b/apps/docs/src/content/docs/properties/position/is.mdx
@@ -1,5 +1,7 @@
 ---
-title: "is"
+title: "Position Type | @position"
+description: "Define positioning method type."
+keywords: ["position", "method", "absolute", "relative", "css"]
 ---
 
 # is

--- a/apps/docs/src/content/docs/properties/position/left.mdx
+++ b/apps/docs/src/content/docs/properties/position/left.mdx
@@ -1,5 +1,7 @@
 ---
-title: "left"
+title: "Left Offset | @position"
+description: "Set left positioning offset for elements."
+keywords: ["position", "left", "offset", "coordinate", "css"]
 ---
 
 # left

--- a/apps/docs/src/content/docs/properties/position/right.mdx
+++ b/apps/docs/src/content/docs/properties/position/right.mdx
@@ -1,5 +1,7 @@
 ---
-title: "right"
+title: "Right Offset | @position"
+description: "Set right positioning offset for elements."
+keywords: ["position", "right", "offset", "coordinate", "css"]
 ---
 
 # right

--- a/apps/docs/src/content/docs/properties/position/top.mdx
+++ b/apps/docs/src/content/docs/properties/position/top.mdx
@@ -1,5 +1,7 @@
 ---
-title: "top"
+title: "Top Offset | @position"
+description: "Set top positioning offset for elements."
+keywords: ["position", "top", "offset", "coordinate", "css"]
 ---
 
 # top

--- a/apps/docs/src/content/docs/properties/position/x.mdx
+++ b/apps/docs/src/content/docs/properties/position/x.mdx
@@ -1,5 +1,7 @@
 ---
-title: "x"
+title: "Horizontal Offset | @position"
+description: "Set horizontal X-axis positioning offset."
+keywords: ["position", "x", "horizontal", "offset", "css"]
 ---
 
 # x

--- a/apps/docs/src/content/docs/properties/position/y.mdx
+++ b/apps/docs/src/content/docs/properties/position/y.mdx
@@ -1,5 +1,7 @@
 ---
-title: "y"
+title: "Vertical Offset | @position"
+description: "Set vertical Y-axis positioning offset."
+keywords: ["position", "y", "vertical", "offset", "css"]
 ---
 
 # y

--- a/apps/docs/src/content/docs/properties/size/height.mdx
+++ b/apps/docs/src/content/docs/properties/size/height.mdx
@@ -1,5 +1,7 @@
 ---
-title: "height"
+title: "Height | @size"
+description: "Control element height dimension."
+keywords: ["size", "height", "dimension", "width", "css"]
 ---
 
 # height

--- a/apps/docs/src/content/docs/properties/size/index.mdx
+++ b/apps/docs/src/content/docs/properties/size/index.mdx
@@ -1,5 +1,9 @@
 ---
-title: "Size Intent Overview"
+title: "Size Intent - Dimension Utilities"
+description:
+  "Sizing with @size intent. Width, height, aspect ratio, and dimension
+  utilities."
+keywords: ["@size", "width", "height", "dimensions", "aspect ratio", "sizing"]
 ---
 
 # Size Intent Overview

--- a/apps/docs/src/content/docs/properties/size/is.mdx
+++ b/apps/docs/src/content/docs/properties/size/is.mdx
@@ -1,5 +1,7 @@
 ---
-title: "is"
+title: "Width and Height | @size"
+description: "Define sizing method type."
+keywords: ["size", "method", "dimension", "unit", "css"]
 ---
 
 # is

--- a/apps/docs/src/content/docs/properties/size/maximum.mdx
+++ b/apps/docs/src/content/docs/properties/size/maximum.mdx
@@ -1,5 +1,7 @@
 ---
-title: "maximum"
+title: "Maximum Size | @size"
+description: "Set maximum dimensions for elements."
+keywords: ["size", "maximum", "max", "constraint", "css"]
 ---
 
 # maximum

--- a/apps/docs/src/content/docs/properties/size/minimum.mdx
+++ b/apps/docs/src/content/docs/properties/size/minimum.mdx
@@ -1,5 +1,7 @@
 ---
-title: "minimum"
+title: "Minimum Size | @size"
+description: "Set minimum dimensions for elements."
+keywords: ["size", "minimum", "min", "constraint", "css"]
 ---
 
 # minimum

--- a/apps/docs/src/content/docs/properties/size/width.mdx
+++ b/apps/docs/src/content/docs/properties/size/width.mdx
@@ -1,5 +1,7 @@
 ---
-title: "width"
+title: "Width | @size"
+description: "Control element width dimension."
+keywords: ["size", "width", "dimension", "height", "css"]
 ---
 
 # width

--- a/apps/docs/src/content/docs/properties/space/gap.mdx
+++ b/apps/docs/src/content/docs/properties/space/gap.mdx
@@ -1,5 +1,7 @@
 ---
-title: "gap"
+title: "Gap Spacing | @space"
+description: "Control gap spacing in flex and grid layouts."
+keywords: ["space", "gap", "spacing", "layout", "css"]
 ---
 
 # gap

--- a/apps/docs/src/content/docs/properties/space/index.mdx
+++ b/apps/docs/src/content/docs/properties/space/index.mdx
@@ -1,5 +1,9 @@
 ---
-title: "Space Intent Overview"
+title: "Space Intent - Spacing Utilities"
+description:
+  "Spacing with @space intent. Margin, padding, gap, and spacing utilities for
+  layout."
+keywords: ["@space", "spacing", "margin", "padding", "gap", "layout spacing"]
 ---
 
 # Space Intent Overview

--- a/apps/docs/src/content/docs/properties/space/margin.mdx
+++ b/apps/docs/src/content/docs/properties/space/margin.mdx
@@ -1,5 +1,7 @@
 ---
-title: "margin"
+title: "Margin | @space"
+description: "Apply margin spacing around elements."
+keywords: ["space", "margin", "spacing", "distance", "css"]
 ---
 
 # margin

--- a/apps/docs/src/content/docs/properties/space/padding.mdx
+++ b/apps/docs/src/content/docs/properties/space/padding.mdx
@@ -1,5 +1,7 @@
 ---
-title: "padding"
+title: "Padding | @space"
+description: "Apply padding spacing inside elements."
+keywords: ["space", "padding", "spacing", "distance", "css"]
 ---
 
 # padding

--- a/apps/docs/src/content/docs/properties/svg/fill.mdx
+++ b/apps/docs/src/content/docs/properties/svg/fill.mdx
@@ -1,5 +1,7 @@
 ---
-title: "fill"
+title: "Fill Color | @svg"
+description: "Set SVG element fill color."
+keywords: ["svg", "fill", "color", "vector", "css"]
 ---
 
 # fill

--- a/apps/docs/src/content/docs/properties/svg/index.mdx
+++ b/apps/docs/src/content/docs/properties/svg/index.mdx
@@ -1,5 +1,9 @@
 ---
-title: "SVG Intent Overview"
+title: "SVG Intent - SVG Styling"
+description:
+  "SVG styling with @svg intent. Control stroke, fill, and SVG element
+  properties."
+keywords: ["@svg", "SVG", "stroke", "fill", "SVG styling"]
 ---
 
 # SVG Intent Overview

--- a/apps/docs/src/content/docs/properties/svg/stroke.mdx
+++ b/apps/docs/src/content/docs/properties/svg/stroke.mdx
@@ -1,5 +1,7 @@
 ---
-title: "stroke"
+title: "Stroke Properties | @svg"
+description: "Set SVG element stroke properties."
+keywords: ["svg", "stroke", "outline", "vector", "css"]
 ---
 
 # stroke

--- a/apps/docs/src/content/docs/properties/table/_layout.mdx
+++ b/apps/docs/src/content/docs/properties/table/_layout.mdx
@@ -1,5 +1,7 @@
 ---
-title: "layout"
+title: "Table Layout Algorithm | @table"
+description: "Control table layout algorithm."
+keywords: ["table", "layout", "algorithm", "cells", "css"]
 ---
 
 # layout

--- a/apps/docs/src/content/docs/properties/table/border.mdx
+++ b/apps/docs/src/content/docs/properties/table/border.mdx
@@ -1,5 +1,7 @@
 ---
-title: "border"
+title: "Table Border | @table"
+description: "Set table borders styling."
+keywords: ["table", "border", "styling", "cells", "css"]
 ---
 
 # border

--- a/apps/docs/src/content/docs/properties/table/caption.mdx
+++ b/apps/docs/src/content/docs/properties/table/caption.mdx
@@ -1,5 +1,7 @@
 ---
-title: "caption"
+title: "Table Caption | @table"
+description: "Style table caption elements."
+keywords: ["table", "caption", "styling", "label", "css"]
 ---
 
 # caption

--- a/apps/docs/src/content/docs/properties/table/gap.mdx
+++ b/apps/docs/src/content/docs/properties/table/gap.mdx
@@ -1,5 +1,7 @@
 ---
-title: "gap"
+title: "Table Gap | @table"
+description: "Control table cell gap spacing."
+keywords: ["table", "gap", "spacing", "cells", "css"]
 ---
 
 # gap

--- a/apps/docs/src/content/docs/properties/table/index.mdx
+++ b/apps/docs/src/content/docs/properties/table/index.mdx
@@ -1,5 +1,10 @@
 ---
-title: "Table Intent Overview"
+title: "Table Intent - Table Layout"
+description:
+  "Table styling with @table intent. Table layout, border-collapse, and table
+  properties."
+keywords:
+  ["@table", "table", "table layout", "border collapse", "table styling"]
 ---
 
 # Table Intent Overview

--- a/apps/docs/src/content/docs/properties/text/align.mdx
+++ b/apps/docs/src/content/docs/properties/text/align.mdx
@@ -1,5 +1,7 @@
 ---
-title: "align"
+title: "Text Alignment | @text"
+description: "Align text content within elements."
+keywords: ["text", "align", "alignment", "justify", "css"]
 ---
 
 # align

--- a/apps/docs/src/content/docs/properties/text/break.mdx
+++ b/apps/docs/src/content/docs/properties/text/break.mdx
@@ -1,5 +1,7 @@
 ---
-title: "break"
+title: "Text Break and Wrap | @text"
+description: "Control text breaking and word wrapping."
+keywords: ["text", "break", "wrap", "overflow", "css"]
 ---
 
 # break

--- a/apps/docs/src/content/docs/properties/text/case.mdx
+++ b/apps/docs/src/content/docs/properties/text/case.mdx
@@ -1,5 +1,7 @@
 ---
-title: "case"
+title: "Text Case | @text"
+description: "Transform text case to upper, lower, or capitalize."
+keywords: ["text", "case", "transform", "upper", "css"]
 ---
 
 # case

--- a/apps/docs/src/content/docs/properties/text/color.mdx
+++ b/apps/docs/src/content/docs/properties/text/color.mdx
@@ -1,5 +1,7 @@
 ---
-title: "color"
+title: "Text Color | @text"
+description: "Set text color for elements."
+keywords: ["text", "color", "foreground", "typography", "css"]
 ---
 
 # color

--- a/apps/docs/src/content/docs/properties/text/content.mdx
+++ b/apps/docs/src/content/docs/properties/text/content.mdx
@@ -1,5 +1,7 @@
 ---
-title: "content"
+title: "Text Content Display | @text"
+description: "Control text content display and overflow."
+keywords: ["text", "content", "display", "overflow", "css"]
 ---
 
 # content

--- a/apps/docs/src/content/docs/properties/text/family.mdx
+++ b/apps/docs/src/content/docs/properties/text/family.mdx
@@ -1,5 +1,7 @@
 ---
-title: "family"
+title: "Font Family | @text"
+description: "Set font family for text elements."
+keywords: ["text", "family", "font", "typeface", "css"]
 ---
 
 # family

--- a/apps/docs/src/content/docs/properties/text/gap.mdx
+++ b/apps/docs/src/content/docs/properties/text/gap.mdx
@@ -1,5 +1,7 @@
 ---
-title: "gap"
+title: "Letter Spacing | @text"
+description: "Control text gap and letter spacing."
+keywords: ["text", "gap", "spacing", "letter", "css"]
 ---
 
 # gap

--- a/apps/docs/src/content/docs/properties/text/index.mdx
+++ b/apps/docs/src/content/docs/properties/text/index.mdx
@@ -1,5 +1,10 @@
 ---
-title: "Text Intent Overview"
+title: "Text Intent - Typography Utilities"
+description:
+  "Typography with @text intent. Font size, weight, color, alignment, and text
+  utilities."
+keywords:
+  ["@text", "typography", "font", "text color", "text alignment", "font size"]
 ---
 
 # Text Intent Overview

--- a/apps/docs/src/content/docs/properties/text/line-height.mdx
+++ b/apps/docs/src/content/docs/properties/text/line-height.mdx
@@ -1,5 +1,7 @@
 ---
-title: "line height"
+title: "Line Height | @text"
+description: "Set line height for text spacing."
+keywords: ["text", "line-height", "spacing", "typography", "css"]
 ---
 
 # line height

--- a/apps/docs/src/content/docs/properties/text/line.mdx
+++ b/apps/docs/src/content/docs/properties/text/line.mdx
@@ -1,5 +1,7 @@
 ---
-title: "line"
+title: "Text Line Properties | @text"
+description: "Control text line properties and behavior."
+keywords: ["text", "line", "break", "wrap", "css"]
 ---
 
 # line

--- a/apps/docs/src/content/docs/properties/text/lines.mdx
+++ b/apps/docs/src/content/docs/properties/text/lines.mdx
@@ -1,5 +1,7 @@
 ---
-title: "lines"
+title: "Line Clamp | @text"
+description: "Control text line clipping and clamping."
+keywords: ["text", "lines", "clamp", "overflow", "css"]
 ---
 
 # lines

--- a/apps/docs/src/content/docs/properties/text/move.mdx
+++ b/apps/docs/src/content/docs/properties/text/move.mdx
@@ -1,5 +1,7 @@
 ---
-title: "move"
+title: "Text Position Offset | @text"
+description: "Apply text positioning and movement."
+keywords: ["text", "move", "position", "offset", "css"]
 ---
 
 # move

--- a/apps/docs/src/content/docs/properties/text/nums.mdx
+++ b/apps/docs/src/content/docs/properties/text/nums.mdx
@@ -1,5 +1,7 @@
 ---
-title: "nums"
+title: "Numeric Formatting | @text"
+description: "Control numeric text formatting."
+keywords: ["text", "numbers", "numeric", "format", "css"]
 ---
 
 # nums

--- a/apps/docs/src/content/docs/properties/text/overflow.mdx
+++ b/apps/docs/src/content/docs/properties/text/overflow.mdx
@@ -1,5 +1,7 @@
 ---
-title: "overflow"
+title: "Text Overflow | @text"
+description: "Handle text overflow with ellipsis."
+keywords: ["text", "overflow", "ellipsis", "truncate", "css"]
 ---
 
 # overflow

--- a/apps/docs/src/content/docs/properties/text/shadow.mdx
+++ b/apps/docs/src/content/docs/properties/text/shadow.mdx
@@ -1,5 +1,7 @@
 ---
-title: "shadow"
+title: "Text Shadow | @text"
+description: "Add text shadow effects."
+keywords: ["text", "shadow", "effect", "depth", "css"]
 ---
 
 # shadow

--- a/apps/docs/src/content/docs/properties/text/size.mdx
+++ b/apps/docs/src/content/docs/properties/text/size.mdx
@@ -1,5 +1,7 @@
 ---
-title: "size"
+title: "Font Size | @text"
+description: "Set font size for text elements."
+keywords: ["text", "size", "font", "typography", "css"]
 ---
 
 # size

--- a/apps/docs/src/content/docs/properties/text/space.mdx
+++ b/apps/docs/src/content/docs/properties/text/space.mdx
@@ -1,5 +1,7 @@
 ---
-title: "space"
+title: "Text Spacing | @text"
+description: "Control text spacing properties."
+keywords: ["text", "space", "spacing", "gap", "css"]
 ---
 
 # space

--- a/apps/docs/src/content/docs/properties/text/style.mdx
+++ b/apps/docs/src/content/docs/properties/text/style.mdx
@@ -1,5 +1,7 @@
 ---
-title: "style"
+title: "Font Style | @text"
+description: "Set font style for text elements."
+keywords: ["text", "style", "italic", "font", "css"]
 ---
 
 # style

--- a/apps/docs/src/content/docs/properties/text/thick.mdx
+++ b/apps/docs/src/content/docs/properties/text/thick.mdx
@@ -1,5 +1,7 @@
 ---
-title: "thick"
+title: "Font Weight | @text"
+description: "Control text font weight thickness."
+keywords: ["text", "thick", "weight", "bold", "css"]
 ---
 
 # thick

--- a/apps/docs/src/content/docs/values/angles.mdx
+++ b/apps/docs/src/content/docs/values/angles.mdx
@@ -1,5 +1,7 @@
 ---
 title: "Angles Dataset"
+description: "Angle values for rotation, skew, and transform operations."
+keywords: ["values", "angles", "degrees", "transform", "css"]
 ---
 
 # Angles Dataset

--- a/apps/docs/src/content/docs/values/blend.mdx
+++ b/apps/docs/src/content/docs/values/blend.mdx
@@ -1,5 +1,7 @@
 ---
 title: "Blend Dataset"
+description: "Blend mode values for mix-blend-mode and compositing."
+keywords: ["values", "blend", "mix-blend-mode", "compositing", "css"]
 ---
 
 # Blend Dataset

--- a/apps/docs/src/content/docs/values/border.mdx
+++ b/apps/docs/src/content/docs/values/border.mdx
@@ -1,5 +1,7 @@
 ---
 title: "Border Dataset"
+description: "Border property values for styling borders."
+keywords: ["values", "border", "style", "width", "css"]
 ---
 
 # Border Dataset

--- a/apps/docs/src/content/docs/values/colors.mdx
+++ b/apps/docs/src/content/docs/values/colors.mdx
@@ -1,5 +1,7 @@
 ---
 title: "Colors Dataset"
+description: "Color value tokens for consistent color theming."
+keywords: ["values", "colors", "palette", "theme", "css"]
 ---
 
 # Colors Dataset

--- a/apps/docs/src/content/docs/values/filter.mdx
+++ b/apps/docs/src/content/docs/values/filter.mdx
@@ -1,5 +1,7 @@
 ---
 title: "Filter Dataset"
+description: "Filter effect values for visual effects."
+keywords: ["values", "filter", "effects", "visual", "css"]
 ---
 
 # Filter Dataset

--- a/apps/docs/src/content/docs/values/flex-grid.mdx
+++ b/apps/docs/src/content/docs/values/flex-grid.mdx
@@ -1,5 +1,7 @@
 ---
 title: "Flex & Grid Dataset"
+description: "Layout values for flexbox and CSS grid systems."
+keywords: ["values", "flex", "grid", "layout", "css"]
 ---
 
 # Flex & Grid Dataset

--- a/apps/docs/src/content/docs/values/flow.mdx
+++ b/apps/docs/src/content/docs/values/flow.mdx
@@ -1,5 +1,7 @@
 ---
 title: "Flow Dataset"
+description: "Flow direction values for layout properties."
+keywords: ["values", "flow", "direction", "layout", "css"]
 ---
 
 # Flow Dataset

--- a/apps/docs/src/content/docs/values/global-values.mdx
+++ b/apps/docs/src/content/docs/values/global-values.mdx
@@ -1,5 +1,7 @@
 ---
 title: "Global Values Dataset"
+description: "Global CSS values used across all properties."
+keywords: ["values", "global", "css", "inherit", "initial"]
 ---
 
 # Global Values Dataset

--- a/apps/docs/src/content/docs/values/index.mdx
+++ b/apps/docs/src/content/docs/values/index.mdx
@@ -1,5 +1,9 @@
 ---
-title: "Values Overview"
+title: "Values and Design Datasets"
+description:
+  "Explore Shilp CSS value datasets. Colors, spacing, filter, timing functions,
+  and more design tokens."
+keywords: ["values", "design tokens", "datasets", "value system"]
 ---
 
 # Values Overview

--- a/apps/docs/src/content/docs/values/numbers.mdx
+++ b/apps/docs/src/content/docs/values/numbers.mdx
@@ -1,5 +1,7 @@
 ---
 title: "Numbers Dataset"
+description: "Numeric value tokens for dimensions and quantities."
+keywords: ["values", "numbers", "numeric", "dimension", "css"]
 ---
 
 # Numbers Dataset

--- a/apps/docs/src/content/docs/values/spacing.mdx
+++ b/apps/docs/src/content/docs/values/spacing.mdx
@@ -1,5 +1,7 @@
 ---
 title: "Spacing Dataset"
+description: "Spacing value tokens for padding and margin."
+keywords: ["values", "spacing", "margin", "padding", "css"]
 ---
 
 # Spacing Dataset

--- a/apps/docs/src/content/docs/values/time.mdx
+++ b/apps/docs/src/content/docs/values/time.mdx
@@ -1,5 +1,7 @@
 ---
 title: "Time Dataset"
+description: "Time value tokens for animation and transition timing."
+keywords: ["values", "time", "timing", "animation", "css"]
 ---
 
 # Time Dataset


### PR DESCRIPTION
- Improve frontmatter data for docs pages
  - Add description
  - Add keywords
  - Improve title
- Fix duplicate `h1`
- Fix wrong pathnames
- Reduce title length of "/work-with-me" page