### PR TITLE
refactor `rss.xml` and improve metadata

### DIFF
--- a/apps/docs/.gitignore
+++ b/apps/docs/.gitignore
@@ -12,6 +12,7 @@
 /.next/
 /out/
 /dist/
+/cache/
 
 # search index
 /public/search-index-*

--- a/apps/docs/CHANGELOG.md
+++ b/apps/docs/CHANGELOG.md
@@ -1,13 +1,32 @@
 # Changelog
 
+## 1.0.0-alpha.5
+
+### Minor Changes
+
+- Add new **changelog** docs pages
+- Refactor `rss.xml` to include only **changelog** pages
+- Disable nextjs telemetry
+- Updated metadata for better SEO and user experience
+- Added keywords to layout and work-with-me pages
+
+### Patch Changes
+
+- From `rss.xml`, remove 1:1 mapping with sitemap
+- Made minor adjustments to the work-with-me page for better structure and
+  readability
+
 ## 1.0.0-alpha.4
 
-## Patch Changes
+### Minor Changes
 
 - Improve frontmatter data for docs pages
   - Add description
   - Add keywords
   - Improve title
+
+### Patch Changes
+
 - Fix duplicate `h1`
 - Fix wrong pathnames
 - Reduce title length of "/work-with-me" page

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "shilpcss-docs",
 	"description": "Shilp CSS documentation",
-	"version": "1.0.0-alpha.4",
+	"version": "1.0.0-alpha.5",
 	"type": "module",
 	"private": true,
 	"scripts": {

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -5,7 +5,7 @@
 	"type": "module",
 	"private": true,
 	"scripts": {
-		"prepare": "node ./scripts/cleanup.js",
+		"preinstall": "pnpm exec next telemetry disable && node ./scripts/cleanup.js",
 		"dev": "next dev --webpack",
 		"build": "next build --webpack"
 	},

--- a/apps/docs/scripts/cleanup.js
+++ b/apps/docs/scripts/cleanup.js
@@ -22,3 +22,5 @@ files
 
 		unlinkSync(filePath);
 	});
+
+console.log(`::::::: DOCS CLEANUP COMPLETED :::::::`);

--- a/apps/docs/src/app/docs/[[...slugs]]/page.jsx
+++ b/apps/docs/src/app/docs/[[...slugs]]/page.jsx
@@ -33,9 +33,13 @@ export const generateMetadata = async ({ params }) => {
 		slugs,
 	});
 
+	const title = metadata.title || meta.title;
+	const description = metadata.description || meta.description || "";
+
 	return {
-		title: metadata.title || meta.title,
-		description: metadata.description || meta.description || "",
+		title,
+		description,
+		keywords: metadata.keywords || meta.keywords || [],
 
 		alternates: {
 			canonical: meta.url,
@@ -45,10 +49,31 @@ export const generateMetadata = async ({ params }) => {
 		},
 
 		openGraph: {
-			title: metadata.title || meta.title,
-			description: metadata.description || meta.description || "",
+			title,
+			description,
 			url: meta.url,
 			type: "article",
+			siteName: "Shilp CSS",
+			locale: "en_US",
+			author: metadata.author || "Pradipsinh Jadeja",
+			images: [
+				{
+					url: "/og.png",
+					width: 1200,
+					height: 630,
+				},
+			],
+		},
+
+		twitter: {
+			title,
+			description,
+			card: "summary_large_image",
+			images: ["/og.png"],
+			site: "@shilpcss",
+			siteId: "2030301913112285184",
+			creator: "@jadeja97_",
+			creatorId: "1951893079608160256",
 		},
 	};
 };

--- a/apps/docs/src/app/layout.jsx
+++ b/apps/docs/src/app/layout.jsx
@@ -16,16 +16,28 @@ import { SITE_URL } from "@/lib/constants";
 
 /* ============================================================================================= */
 
+const title = "Shilp CSS";
+const description =
+	"an Intent-first, CSS-centric, styling engine and framework";
+
 export const metadata = {
 	//
 	metadataBase: new URL(SITE_URL),
 
 	title: {
-		default: "Shilp CSS",
+		default: title,
 		template: "%s | Shilp CSS",
 	},
 
-	description: "an Intent-first, CSS-centric, styling engine and framework",
+	description,
+	keywords: [
+		"shilp css",
+		"framework",
+		"library",
+		"styling engine",
+		"intent-first css",
+		"css-centric styling",
+	],
 
 	alternates: {
 		canonical: "/",
@@ -37,8 +49,13 @@ export const metadata = {
 	},
 
 	openGraph: {
+		title,
+		description,
+		url: SITE_URL,
 		type: "website",
 		siteName: "Shilp CSS",
+		locale: "en_US",
+		author: "Pradipsinh Jadeja",
 		images: [
 			{
 				url: "/og.png",
@@ -49,8 +66,14 @@ export const metadata = {
 	},
 
 	twitter: {
+		title,
+		description,
 		card: "summary_large_image",
 		images: ["/og.png"],
+		site: "@shilpcss",
+		siteId: "2030301913112285184",
+		creator: "@jadeja97_",
+		creatorId: "1951893079608160256",
 	},
 };
 

--- a/apps/docs/src/app/rss.xml/route.js
+++ b/apps/docs/src/app/rss.xml/route.js
@@ -1,6 +1,7 @@
 import { SITE_URL } from "@/lib/constants";
 
 import Content from "@/lib/content";
+import loadDocsModule from "@/lib/load-docs-module";
 
 /* ============================================================================================= */
 
@@ -18,39 +19,25 @@ export const revalidate = false;
 /**
  * Generates RSS feed for documentation updates
  */
-export const GET = () => {
-	//
-	const slugs = content.getAllSlugs();
+export const GET = async () => {
+	// RSS items from changelog pages
+	const items = [];
 
-	const pages = [
-		{
-			title: "Work With Me",
-			description:
-				"Work with the creator of Shilp CSS, an open-source CSS engine and framework. He is available for frontend engineering, architecture, consulting, product collaboration, and sponsorship for Shilp CSS.",
-			url: `${SITE_URL}/work-with-me/`,
-			guid: "work-with-me",
-		},
-	];
+	// changelog slugs
+	const changelogSlugs = content
+		.getAllSlugs()
+		.filter(({ slugs }) => slugs[0] === "changelog" && slugs.length > 1);
 
-	// Build RSS items from all doc pages
-	const items = slugs.map(({ slugs }) => {
-		//
-		const { meta } = content.getFileInfo(slugs);
+	for (const _slugs of changelogSlugs) {
+		const item = await getRSSItemsMeta(_slugs.slugs);
+		items.push(item);
+	}
 
-		return createRSSItem({
-			title: meta.title,
-			url: `${SITE_URL}${meta.url}/`,
-			guid: slugs.join(""),
-		});
-	});
+	// changelogs sorted by descending date
+	const sortedItems = items.sort((a, b) => +b.date - +a.date);
 
 	// Generate RSS XML
-	const rss = generateRSSFeed(
-		pages
-			.map((page) => createRSSItem(page))
-			.concat(items)
-			.join("\n"),
-	);
+	const rss = generateRSSFeed(sortedItems.map(createRSSItem).join("\n"));
 
 	return new Response(rss, {
 		headers: {
@@ -62,16 +49,35 @@ export const GET = () => {
 
 /* ============================================================================================= */
 
-const createRSSItem = ({ title, description, url, guid }) => {
+const getRSSItemsMeta = async (slugs) => {
+	//
+	const { metadata, meta } = await loadDocsModule({
+		content,
+		slugs,
+	});
+
+	return {
+		title: metadata.title || meta.title,
+		description: metadata.description || meta.description,
+		url: `${SITE_URL}${meta.url}/`,
+		guid: slugs.join(""),
+		date: metadata.date ? new Date(metadata.date) : new Date(),
+	};
+};
+
+/* ============================================================================================= */
+
+const createRSSItem = ({ title, description, url, guid, date }) => {
 	//
 	return `
-  <item>
-    <title>${escapeXML(title)}</title>
-    <description>${escapeXML(description ?? `content for ${title}`)}</description>
-    <link>${escapeXML(url)}</link>
-    <guid>${escapeXML(guid || url)}</guid>
-    <pubDate>${new Date().toUTCString()}</pubDate>
-  </item>`;
+		<item>
+			<title>${escapeXML(title || "Untitled")}</title>
+			<description>${escapeXML(description ?? `content for ${title}`)}</description>
+			<link>${escapeXML(url)}</link>
+			<guid>${escapeXML(guid || url)}</guid>
+			<pubDate>${date.toUTCString()}</pubDate>
+		</item>
+	`;
 };
 
 /* ============================================================================================= */
@@ -84,17 +90,16 @@ const generateRSSFeed = (items) => {
 	const feedDate = new Date().toUTCString();
 
 	return `<?xml version="1.0" encoding="UTF-8"?>
-<rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/">
+<rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:atom="http://www.w3.org/2005/Atom">
 	<channel>
-		<title>Shilp CSS</title>
-		<link>${SITE_URL}</link>
-		<description>an Intent-first, CSS-centric, styling engine and framework</description>
+		<title>Shilp CSS Changelog</title>
+		<link>${SITE_URL}/docs/changelog/</link>
+		<description>Latest updates and announcements for Shilp CSS</description>
 		<language>en-us</language>
+		<atom:link href="${SITE_URL}/rss.xml" rel="self" type="application/rss+xml"/>
 		<lastBuildDate>${feedDate}</lastBuildDate>
 		<ttl>3600</ttl>
-
     ${items}
-
 	</channel>
 </rss>`;
 };

--- a/apps/docs/src/app/work-with-me/page.jsx
+++ b/apps/docs/src/app/work-with-me/page.jsx
@@ -1,46 +1,98 @@
 import List from "@/components/list";
 import Separator from "@/components/separator";
+import Headings from "@/markdown/components/heading";
+
+import { SITE_URL } from "@/lib/constants";
 
 /* ============================================================================================= */
+
+const title = "Work With Shilp CSS Creator - Pradipsinh Jadeja";
+const description =
+	"Work with the creator of Shilp CSS, an open-source CSS engine and framework. He is available for frontend engineering, architecture, consulting, product collaboration, and sponsorship for Shilp CSS.";
 
 export const metadata = {
 	//
 	title: {
-		absolute: "Work With Shilp CSS Creator - Pradipsinh Jadeja",
+		absolute: title,
 	},
 
-	description:
-		"Work with the creator of Shilp CSS, an open-source CSS engine and framework. He is available for frontend engineering, architecture, consulting, product collaboration, and sponsorship for Shilp CSS.",
+	description,
+
+	keywords: [
+		"work with me",
+		"pradipsinh jadeja",
+		"shilp css creator",
+		"frontend engineer",
+		"product collaboration",
+		"consulting",
+		"sponsorship",
+	],
 
 	alternates: {
 		canonical: "/work-with-me",
+		types: {
+			"text/markdown":
+				"https://raw.githubusercontent.com/jadeja97/jadeja97/refs/heads/main/README.md",
+		},
+	},
+
+	openGraph: {
+		title,
+		description,
+		url: `${SITE_URL}/work-with-me`,
+		type: "article",
+		siteName: "Shilp CSS",
+		locale: "en_US",
+		author: "Pradipsinh Jadeja",
+		images: [
+			{
+				url: "/og.png",
+				width: 1200,
+				height: 630,
+			},
+		],
+	},
+
+	twitter: {
+		title,
+		description,
+		card: "summary_large_image",
+		images: ["/og.png"],
+		site: "@shilpcss",
+		siteId: "2030301913112285184",
+		creator: "@jadeja97_",
+		creatorId: "1951893079608160256",
 	},
 };
 
 /* ============================================================================================= */
 
 const WorkWithMe = () => (
-	<main id="work-with-me" className="container page-layout typography">
-		{/*  */}
+	<main id="work-with-me" className="container page-layout">
+		<article className="typography">
+			{/*  */}
 
-		<HeroSection />
+			<HeroSection />
 
-		<Strength />
+			<OpenTo />
 
-		<CurrentFocus />
+			<Strength />
 
-		<WorkTogether />
+			<CurrentFocus />
 
-		<Contact />
+			<WorkTogether />
 
-		<br />
-		<br />
+			<Contact />
 
-		<Separator />
+			<br />
+			<br />
 
-		<p>Thank you for your time 🙂</p>
+			<Separator />
 
-		{/*  */}
+			<p>Thank you for your time 🙂</p>
+
+			{/*  */}
+		</article>
 	</main>
 );
 
@@ -48,7 +100,9 @@ const WorkWithMe = () => (
 
 const HeroSection = () => (
 	<>
-		<h1>Work With Me</h1>
+		<Headings as="h1" id="work-with-me">
+			Work With Me
+		</Headings>
 		<p>
 			Hi, my name is <strong>Pradipsinh Jadeja</strong>.<br />
 			<strong>Creator of Shilp CSS and Senior Frontend Engineer</strong>.
@@ -57,9 +111,17 @@ const HeroSection = () => (
 			I am open to working with teams that value strong engineering fundamentals
 			and product thinking.
 		</p>
-		<p>
-			<strong>Open to</strong>:
-		</p>
+	</>
+);
+
+/* ============================================================================================= */
+
+const OpenTo = () => (
+	<section>
+		<Headings as="h2" id="open-to">
+			Open To
+		</Headings>
+
 		<List>
 			<li>Frontend Engineer role</li>
 			<li>Product-focused startups and engineering teams</li>
@@ -71,14 +133,15 @@ const HeroSection = () => (
 			I prefer remote work and collaborate effectively with distributed teams,
 			and I am open to discussing what works best for the team.
 		</p>
-	</>
+	</section>
 );
-
 /* ============================================================================================= */
 
 const Strength = () => (
 	<section>
-		<h2>What I Bring To The Table</h2>
+		<Headings as="h2" id="what-i-bring-to-the-table">
+			What I Bring To The Table
+		</Headings>
 
 		<p>
 			My core strength is quickly understanding how systems work, identifying
@@ -117,7 +180,9 @@ const Strength = () => (
 
 const CurrentFocus = () => (
 	<section>
-		<h2>Current Focus</h2>
+		<Headings as="h2" id="current-focus">
+			Current Focus
+		</Headings>
 
 		<p>
 			I am actively investing my time in building the development of Shilp CSS.
@@ -148,7 +213,9 @@ const CurrentFocus = () => (
 
 const WorkTogether = () => (
 	<section>
-		<h2>How We Can Work Together</h2>
+		<Headings as="h2" id="how-we-can-work-together">
+			How We Can Work Together
+		</Headings>
 
 		<p>Reach out if you are:</p>
 		<List>
@@ -170,7 +237,9 @@ const WorkTogether = () => (
 
 const Contact = () => (
 	<section>
-		<h2>Contact</h2>
+		<Headings as="h2" id="contact">
+			Contact
+		</Headings>
 
 		<p>
 			Work Email: <br /> <code>pajadeja117@gmail.com</code>

--- a/apps/docs/src/content/docs/(root)/changelog.mdx
+++ b/apps/docs/src/content/docs/(root)/changelog.mdx
@@ -1,0 +1,15 @@
+---
+title: Changelog
+description: Latest updates and announcements.
+date: "2026/04/24"
+---
+
+# Changelog
+
+Latest updates and announcements for Shilp CSS.
+
+---
+
+| Date       | Description                   | Log                            |
+| ---------- | ----------------------------- | ------------------------------ |
+| 2026/04/20 | Shilp CSS - `alpha.0` release | [See](/docs/changelog/alpha.0) |

--- a/apps/docs/src/content/docs/(root)/meta.json
+++ b/apps/docs/src/content/docs/(root)/meta.json
@@ -17,6 +17,7 @@
 		{
 			"name": "setup",
 			"label": "setup shilp CSS"
-		}
+		},
+		"changelog"
 	]
 }

--- a/apps/docs/src/content/docs/changelog/alpha.0.mdx
+++ b/apps/docs/src/content/docs/changelog/alpha.0.mdx
@@ -1,0 +1,41 @@
+---
+title: "Shilp CSS alpha.0 release announcement"
+description:
+  "Shilp CSS entered Alpha on April 20, 2026. A new CSS engine and framework,
+  focused on structure, predictability, and long-term maintainability."
+keywords: ["Shilp CSS", "alpha.0", "Release", "CSS Engine", "Framework"]
+date: "2026/04/20"
+---
+
+# alpha.0
+
+Shilp CSS has officially entered the **Alpha** stage on April 20, 2026.
+
+This release marks the first public milestone. The foundation and core
+architecture are now stable enough for early exploration, feedback, and
+experimentation.
+
+<Alert variant="info">
+
+See: [Latest Status](/docs/status)
+
+</Alert>
+
+---
+
+<section>
+
+## Feedback
+
+If you encounter issues, have suggestions, or want to contribute, please read
+our
+[Contribution Guidelines](https://github.com/JadejaHQ/shilpcss/blob/main/CONTRIBUTING.md)
+first.
+
+Your feedback is essential to shaping Shilp CSS.
+
+</section>
+
+---
+
+Thank you for your time 🙂

--- a/apps/docs/src/content/docs/changelog/meta.json
+++ b/apps/docs/src/content/docs/changelog/meta.json
@@ -1,0 +1,10 @@
+{
+	"label": "Changelog",
+	"items": [
+		{
+			"name": "alpha.0",
+			"label": "alpha 0",
+			"title": "Shilp CSS - alpha.0 release"
+		}
+	]
+}

--- a/apps/docs/src/content/docs/meta.json
+++ b/apps/docs/src/content/docs/meta.json
@@ -39,6 +39,10 @@
 		{
 			"type": "folder",
 			"name": "best-practices"
+		},
+		{
+			"type": "folder",
+			"name": "changelog"
 		}
 	]
 }


### PR DESCRIPTION
- Add new **changelog** docs pages
- Refactor `rss.xml` to include only **changelog** pages
  - remove 1:1 mapping with sitemap
- Updated metadata for better SEO and user experience
- Added keywords to layout and work-with-me pages
- Made minor adjustments to the work-with-me page for better structure and readability
- Disable nextjs telemetry