### PR TITLE
Improve content pages's label, title and description (#34)

### DIFF
--- a/apps/docs/CHANGELOG.md
+++ b/apps/docs/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 1.0.0-alpha.6
+
+### Minor Changes
+
+- feat: add basic usage example for properties and mixins
+
+### Patch Changes
+
+- refactor: separate **backdrop filter** from **filter**
+  - create a new folder in content and moved backdrop related filters
+  - move indent indicator from `li` to `li a` for `data-folder-page`
+- fix: add correct description for text intent's utilites
+- refactor: add correct titles, descriptions for all docs pages
+- refactor: docs topics navigation label
+  - make properties labels match utility's first token
+    - links url and text changed accordingly
+    - for `scroll-m` and `scroll-p`, an additional label was required
+  - exlude `/docs/changelog` from `uppercase` styles
+  - removed files and folder `title` to be inherited from `label`
+
 ## 1.0.0-alpha.5
 
 ### Minor Changes

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "shilpcss-docs",
 	"description": "Shilp CSS documentation",
-	"version": "1.0.0-alpha.5",
+	"version": "1.0.0-alpha.6",
 	"type": "module",
 	"private": true,
 	"scripts": {

--- a/apps/docs/src/content/docs/(core-concepts)/colors.mdx
+++ b/apps/docs/src/content/docs/(core-concepts)/colors.mdx
@@ -5,10 +5,15 @@ description:
   color tokens, and default dark mode support."
 keywords:
   [
-    "color system",
-    "OKLCH format",
-    "design tokens",
-    "color palette",
+    "colors",
+    "system",
+    "OKLCH",
+    "design",
+    "tokens",
+    "roles",
+    "branding",
+    "semantic",
+    "palette",
     "dark mode",
   ]
 ---

--- a/apps/docs/src/content/docs/(core-concepts)/index.mdx
+++ b/apps/docs/src/content/docs/(core-concepts)/index.mdx
@@ -4,7 +4,17 @@ description:
   "Explore Shilp CSS core concepts: intents, theming, responsive design, colors,
   dark mode, and browser compatibility for modern CSS."
 keywords:
-  ["core concepts", "CSS fundamentals", "responsive design", "theming system"]
+  [
+    "core concepts",
+    "CSS fundamentals",
+    "responsive design",
+    "theming system",
+    "intents",
+    "mixins",
+    "colors",
+    "dark mode",
+    "browser compatibility",
+  ]
 ---
 
 # Core Concepts

--- a/apps/docs/src/content/docs/(core-concepts)/responsive-design.mdx
+++ b/apps/docs/src/content/docs/(core-concepts)/responsive-design.mdx
@@ -1,8 +1,8 @@
 ---
 title: "Responsive Design in Shilp CSS"
 description:
-  "Master responsive design with Shilp CSS breakpoints. Mobile-first approach,
-  default breakpoints, and responsive utilities."
+  "Responsive design with breakpoints. Mobile-first approach, default
+  breakpoints, and @screen mixin."
 keywords:
   [
     "responsive design",
@@ -10,6 +10,7 @@ keywords:
     "mobile-first",
     "media queries",
     "screen sizes",
+    "@screen mixin",
   ]
 ---
 

--- a/apps/docs/src/content/docs/(core-concepts)/styling-with-intent.mdx
+++ b/apps/docs/src/content/docs/(core-concepts)/styling-with-intent.mdx
@@ -4,12 +4,7 @@ description:
   "Learn intent-based styling in Shilp CSS. Organize styles by responsibility
   using intents like @layout, @text, @bg, and stateful mixins."
 keywords:
-  [
-    "intent-based styling",
-    "styling methodology",
-    "CSS organization",
-    "responsibilities",
-  ]
+  ["intent", "intent-based styling", "CSS organization", "stateful intent"]
 ---
 
 # Styling With Intent

--- a/apps/docs/src/content/docs/(core-concepts)/theming.mdx
+++ b/apps/docs/src/content/docs/(core-concepts)/theming.mdx
@@ -1,8 +1,8 @@
 ---
 title: "Theming and Design Tokens"
 description:
-  "Master theming in Shilp CSS. Create design tokens, semantic color systems,
-  and customize typography and spacing."
+  "Theming in Shilp CSS. Create design tokens, semantic color systems, and
+  customize typography and spacing."
 keywords:
   [
     "theming",

--- a/apps/docs/src/content/docs/(root)/changelog.mdx
+++ b/apps/docs/src/content/docs/(root)/changelog.mdx
@@ -1,5 +1,5 @@
 ---
-title: Changelog
+title: Shilp CSS Changelog
 description: Latest updates and announcements.
 date: "2026/04/24"
 ---

--- a/apps/docs/src/content/docs/(root)/setup.mdx
+++ b/apps/docs/src/content/docs/(root)/setup.mdx
@@ -4,7 +4,7 @@ description:
   "Step-by-step installation guide for Shilp CSS with Vite and Webpack.
   Configure bundler plugins and optimize your styling workflow."
 keywords:
-  ["installation", "setup guide", "Vite plugin", "Webpack", "configuration"]
+  ["install", "setup", "Vite", "Webpack", "plugin", "bundler", "configuration"]
 ---
 
 # Setup Shilp CSS

--- a/apps/docs/src/content/docs/best-practices/property-config-patterns.mdx
+++ b/apps/docs/src/content/docs/best-practices/property-config-patterns.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Property Configuration Patterns"
 description:
-  "Explore 8 common property config patterns in Shilp CSS. Learn utilities
+  "Explore common property config patterns in Shilp CSS. Learn utilities
   structure, variants, presets, and CSS variables."
 keywords:
   [

--- a/apps/docs/src/content/docs/changelog/alpha.0.mdx
+++ b/apps/docs/src/content/docs/changelog/alpha.0.mdx
@@ -25,6 +25,17 @@ See: [Latest Status](/docs/status)
 
 <section>
 
+## The Purpose
+
+The goal is simple, keep styling decisions deliberate and centralized in CSS.
+
+The scope is intentionally small, and this stage is about validating the core
+model and making sure the foundation is solid before expanding further.
+
+</section>
+
+<section>
+
 ## Feedback
 
 If you encounter issues, have suggestions, or want to contribute, please read

--- a/apps/docs/src/content/docs/changelog/meta.json
+++ b/apps/docs/src/content/docs/changelog/meta.json
@@ -1,9 +1,8 @@
 {
-	"label": "Changelog",
+	"label": "changelog",
 	"items": [
 		{
 			"name": "alpha.0",
-			"label": "alpha 0",
 			"title": "Shilp CSS - alpha.0 release"
 		}
 	]

--- a/apps/docs/src/content/docs/default-styles/variables.mdx
+++ b/apps/docs/src/content/docs/default-styles/variables.mdx
@@ -111,7 +111,7 @@ Each system is documented in detail in the **properties documentation**.
 | Box Shadow      | Composes `box-shadow` using size, color, and inset.                                                      | [Box Shadow](/docs/properties/layout/shadow)               |
 | Text Shadow     | Composes `text-shadow` using size and color.                                                             | [Text Shadow](/docs/properties/text/shadow)                |
 | Drop Shadow     | Composes `filter` based `drop-shadow` using size and color.                                              | [Drop Shadow](/docs/properties/filter/shadow)              |
-| Backdrop Shadow | Similar to `drop-shadow` but applied through `backdrop-filter`.                                          | [Backdrop Shadow](/docs/properties/filter/backdrop-shadow) |
+| Backdrop Shadow | Similar to `drop-shadow` but applied through `backdrop-filter`.                                          | [Backdrop Shadow](/docs/properties/filter/backdrop/shadow) |
 
 </section>
 

--- a/apps/docs/src/content/docs/life-cycle/pre-processing.mdx
+++ b/apps/docs/src/content/docs/life-cycle/pre-processing.mdx
@@ -2,12 +2,15 @@
 title: "Pre-processing Stage"
 description:
   "Learn about Shilp CSS pre-processing stage. Configuration preparation and
-  initial CSS parsing."
+  initial SCSS parsing."
 keywords:
   ["pre-processing", "build stage", "configuration processing", "initial stage"]
 ---
 
 # Pre-processing
+
+Shilp CSS pre-processing stage. Configuration preparation and initial SCSS
+parsing.
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/life-cycle/processing.mdx
+++ b/apps/docs/src/content/docs/life-cycle/processing.mdx
@@ -9,6 +9,9 @@ keywords:
 
 # Processing
 
+Shilp CSS processing stage. Intent parsing and CSS generation from intent
+syntax.
+
 <Alert variant="info">
 
 Content will be added progressively in future updates.

--- a/apps/docs/src/content/docs/life-cycle/purging.mdx
+++ b/apps/docs/src/content/docs/life-cycle/purging.mdx
@@ -1,12 +1,15 @@
 ---
 title: "Purging Stage - Unused CSS Removal"
 description:
-  "Understand CSS purging in Shilp CSS. Remove unused styles during build using
-  PurgeCSS integration."
+  "Understand CSS purging in Shilp CSS. Remove unused styles after build
+  generation with Purge CSS integration."
 keywords: ["purging", "unused CSS", "PurgeCSS", "build optimization"]
 ---
 
 # Purging
+
+CSS purging in Shilp CSS. Remove unused styles after build generation with Purge
+CSS integration.
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/life-cycle/transpiling.mdx
+++ b/apps/docs/src/content/docs/life-cycle/transpiling.mdx
@@ -9,6 +9,9 @@ keywords:
 
 # Transpiling
 
+CSS transpiling in Shilp CSS. Modern CSS features, vendor prefixes, and browser
+compatibility.
+
 <Alert variant="info">
 
 Content will be added progressively in future updates.

--- a/apps/docs/src/content/docs/mixins/aria.mdx
+++ b/apps/docs/src/content/docs/mixins/aria.mdx
@@ -1,13 +1,26 @@
 ---
 title: "@aria Mixin for Accessibility"
-description:
-  "Use @aria mixin for ARIA attribute selectors in Shilp CSS styling."
+description: "Use @aria mixin for ARIA attribute selectors in Shilp CSS."
 keywords: ["@aria", "ARIA", "accessibility mixin", "attribute selector"]
 ---
 
 # @aria Mixin
 
-apply styles based on `aria-*`
+Use `@aria` mixin for ARIA attribute (`aria-*`) selectors.
+
+Usage:
+
+Usage:
+
+```css
+.any-class {
+	/* normal */
+	@aria <variant> { ... }
+
+	/* functions */
+	@childs <variant>("<arguments>") { ... }
+}
+```
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/mixins/childs.mdx
+++ b/apps/docs/src/content/docs/mixins/childs.mdx
@@ -1,12 +1,24 @@
 ---
 title: "@childs Mixin - Child Element Selector"
-description: "Use @childs mixin to style direct child elements in Shilp CSS."
+description: "Use @childs mixin to style child elements in Shilp CSS."
 keywords: ["@childs", "child selector", "child elements", "structural selector"]
 ---
 
 # @childs Mixin
 
-target child elements
+Use `@childs` mixin to style child elements.
+
+Usage:
+
+```css
+.any-class {
+	/* direct */
+	@childs <variant> { ... }
+
+	/* functions */
+	@childs <variant>("<arguments>") { ... }
+}
+```
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/mixins/data.mdx
+++ b/apps/docs/src/content/docs/mixins/data.mdx
@@ -1,13 +1,24 @@
 ---
 title: "@data Mixin - Data Attributes"
-description:
-  "Use @data mixin for data attribute selectors in conditional styling."
+description: "Use @data mixin for data attribute selectors in Shilp CSS."
 keywords: ["@data", "data attributes", "conditional styling", "mixin variants"]
 ---
 
 # @data Mixin
 
-apply styles based on `data-*` attributes
+Use `@data` mixin for data attribute (`data-*`) selectors.
+
+Usage:
+
+```css
+.any-class {
+	/* direct */
+	@data <variant> { ... }
+
+	/* functions */
+	@data <variant>("<arguments>") { ... }
+}
+```
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/mixins/env.mdx
+++ b/apps/docs/src/content/docs/mixins/env.mdx
@@ -1,12 +1,21 @@
 ---
-title: "@env Mixin - Environment Queries"
-description: "Use @env mixin for CSS environment variable queries in Shilp CSS."
+title: "@env Mixin - Environment"
+description: "Use @env mixin for styling based on environment in Shilp CSS."
 keywords: ["@env", "environment", "CSS environment", "viewport queries"]
 ---
 
 # @env Mixin
 
-environment-based selectors like tall, print
+Use `@env` mixin for styling based on environment.
+
+Usage:
+
+```css
+.any-class {
+	/* direct */
+	@env <variant> { ... }
+}
+```
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/mixins/form.mdx
+++ b/apps/docs/src/content/docs/mixins/form.mdx
@@ -7,7 +7,16 @@ keywords: ["@form", "form mixin", "form states", "input states"]
 
 # @form Mixin
 
-form-related state selectors
+Use `@form` mixin for form element states and conditions.
+
+Usage:
+
+```css
+.any-class {
+	/* direct */
+	@form <variant> { ... }
+}
+```
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/mixins/index.mdx
+++ b/apps/docs/src/content/docs/mixins/index.mdx
@@ -47,18 +47,18 @@ This section lists all built-in mixins shipped with Shilp CSS.
 
 | Mixin       | Description                                  | Documentation                      |
 | ----------- | -------------------------------------------- | ---------------------------------- |
-| `@aria`     | apply styles based on `aria-*` attributes    | [@aria](/docs/mixins/aria)         |
-| `@childs`   | target child elements                        | [@childs](/docs/mixins/childs)     |
-| `@data`     | apply styles based on `data-*` attributes    | [@data](/docs/mixins/data)         |
-| `@env`      | environment-based selectors like tall, print | [@env](/docs/mixins/env)           |
-| `@form`     | form-related state selectors                 | [@form](/docs/mixins/form)         |
-| `@match`    | control selector matching like `:not`, `:is` | [@match](/docs/mixins/match)       |
-| `@motion`   | motion-related selectors like reduced motion | [@motion](/docs/mixins/motion)     |
+| `@aria`     | ARIA attribute (`aria-*`) selectors          | [@aria](/docs/mixins/aria)         |
+| `@childs`   | style child elements                         | [@childs](/docs/mixins/childs)     |
+| `@data`     | data attribute (`data-*`) selectors          | [@data](/docs/mixins/data)         |
+| `@env`      | styling based on environment                 | [@env](/docs/mixins/env)           |
+| `@form`     | form element states and conditions           | [@form](/docs/mixins/form)         |
+| `@match`    | complex selector patterns                    | [@match](/docs/mixins/match)       |
+| `@motion`   | respecting user motion preferences           | [@motion](/docs/mixins/motion)     |
 | `@screen`   | responsive breakpoints and media queries     | [@screen](/docs/mixins/screen)     |
-| `@self`     | target the current element                   | [@self](/docs/mixins/self)         |
-| `@siblings` | target sibling elements                      | [@siblings](/docs/mixins/siblings) |
-| `@state`    | UI states like hover, focus                  | [@state](/docs/mixins/state)       |
-| `@text`     | text-related selectors                       | [@text](/docs/mixins/text)         |
-| `@theme`    | theme-based selectors like dark/light mode   | [@theme](/docs/mixins/theme)       |
+| `@self`     | apply styles to the element itself           | [@self](/docs/mixins/self)         |
+| `@siblings` | style sibling elements                       | [@siblings](/docs/mixins/siblings) |
+| `@state`    | interactive states                           | [@state](/docs/mixins/state)       |
+| `@text`     | text-related conditions and pseudo-selectors | [@text](/docs/mixins/text)         |
+| `@theme`    | **dark/light** mode and **custom theme**     | [@theme](/docs/mixins/theme)       |
 
 </section>

--- a/apps/docs/src/content/docs/mixins/match.mdx
+++ b/apps/docs/src/content/docs/mixins/match.mdx
@@ -9,7 +9,16 @@ keywords:
 
 # @match Mixin
 
-control selector matching like `:not`, `:is`
+Use `@match` mixin for complex selector patterns.
+
+Usage:
+
+```css
+.any-class {
+	/* functions */
+	@match <variant>("<arguments>") { ... }
+}
+```
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/mixins/motion.mdx
+++ b/apps/docs/src/content/docs/mixins/motion.mdx
@@ -8,7 +8,16 @@ keywords:
 
 # @motion Mixin
 
-motion-related selectors like reduced motion
+Use `@motion` mixin for respecting user motion preferences.
+
+Usage:
+
+```css
+.any-class {
+	/* direct */
+	@motion <variant> { ... }
+}
+```
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/mixins/screen.mdx
+++ b/apps/docs/src/content/docs/mixins/screen.mdx
@@ -8,7 +8,16 @@ keywords:
 
 # @screen Mixin
 
-responsive breakpoints and media queries
+Use `@screen` mixin for responsive breakpoints and media queries.
+
+Usage:
+
+```css
+.any-class {
+	/* direct */
+	@screen <variant> { ... }
+}
+```
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/mixins/self.mdx
+++ b/apps/docs/src/content/docs/mixins/self.mdx
@@ -7,7 +7,19 @@ keywords: ["@self", "self selector", "element selector", "conditional styling"]
 
 # @self Mixin
 
-arget the current element
+Use `@self` mixin to apply styles to the element itself with conditions.
+
+Usage:
+
+```css
+.any-class {
+	/* direct */
+	@self <variant> { ... }
+
+	/* functions */
+	@self <variant>("<arguments>") { ... }
+}
+```
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/mixins/siblings.mdx
+++ b/apps/docs/src/content/docs/mixins/siblings.mdx
@@ -8,7 +8,16 @@ keywords:
 
 # @siblings Mixin
 
-target sibling elements
+Use `@siblings` mixin to style sibling elements.
+
+Usage:
+
+```css
+.any-class {
+	/* functions */
+	@siblings <variant>("<arguments>") { ... }
+}
+```
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/mixins/state.mdx
+++ b/apps/docs/src/content/docs/mixins/state.mdx
@@ -8,7 +8,16 @@ keywords: ["@state", "UI states", "hover", "focus", "active", "disabled"]
 
 # @state Mixin
 
-UI states like hover, focus
+Use `@state` mixin for interactive states.
+
+Usage:
+
+```css
+.any-class {
+	/* direct */
+	@state <variant> { ... }
+}
+```
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/mixins/text.mdx
+++ b/apps/docs/src/content/docs/mixins/text.mdx
@@ -6,7 +6,16 @@ keywords: ["@text", "text mixin", "text conditions", "text selectors"]
 
 # @text Mixin
 
-text-related selectors
+Use `@text` mixin for text-related conditions and pseudo-selectors.
+
+Usage:
+
+```css
+.any-class {
+	/* direct */
+	@text <variant> { ... }
+}
+```
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/mixins/theme.mdx
+++ b/apps/docs/src/content/docs/mixins/theme.mdx
@@ -7,7 +7,16 @@ keywords: ["@theme", "dark mode", "light mode", "theme variants", "theming"]
 
 # @theme Mixin
 
-theme-based selectors like dark/light mode
+Use `@theme` mixin for **dark/light** mode and **custom theme**.
+
+Usage:
+
+```css
+.any-class {
+	/* direct */
+	@theme <variant> { ... }
+}
+```
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/adjust/backside.mdx
+++ b/apps/docs/src/content/docs/properties/adjust/backside.mdx
@@ -1,12 +1,16 @@
 ---
-title: "Backface Visibility | @adjust"
+title: "Backside Visibility | @adjust"
 description: "Control backface visibility for 3D transforms and rotations."
-keywords: ["transform", "3d", "backside", "visibility", "css"]
+keywords: ["transform", "3d", "backside", "visibility"]
 ---
 
-# backside
+# Backside Visibility
 
-backface visibility
+Control backface visibility for 3D transforms and rotations.
+
+Usage:
+
+- `@adjust backside-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/adjust/distance.mdx
+++ b/apps/docs/src/content/docs/properties/adjust/distance.mdx
@@ -1,12 +1,20 @@
 ---
-title: "Transform Perspective | @adjust"
-description: "Set translation distance for transform positioning and movement."
-keywords: ["transform", "translate", "distance", "positioning", "css"]
+title: "Transform Distance or Perspective | @adjust"
+description:
+  "Set translationtra distance (perspective) for transform positioning, movement
+  and origin."
+keywords: ["transform", "translate", "distance", "positioning"]
 ---
 
-# distance
+# Transform Distance OR Perspective
 
-perspective and it's origin
+Set translation distance (perspective) for transform positioning, movement and
+origin.
+
+Usage:
+
+- `@adjust distance-*;`
+- `@adjust distance-origin-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/adjust/index.mdx
+++ b/apps/docs/src/content/docs/properties/adjust/index.mdx
@@ -12,14 +12,14 @@ Adjust intent contains element's `transform` related utilities.
 
 Utilities available in `@adjust` intent are listed below.
 
-| Utility      | Description                 | Documentation                                |
-| ------------ | --------------------------- | -------------------------------------------- |
-| `backside-*` | backface visibility         | [backside](/docs/properties/adjust/backside) |
-| `distance-*` | perspective and it's origin | [distance](/docs/properties/adjust/distance) |
-| `move-*`     | move element                | [move](/docs/properties/adjust/move)         |
-| `origin-*`   | transform origin            | [origin](/docs/properties/adjust/origin)     |
-| `preset-*`   | `transform` property        | [preset](/docs/properties/adjust/preset)     |
-| `rotate-*`   | rotate element              | [rotate](/docs/properties/adjust/rotate)     |
-| `scale-*`    | scale element               | [scale](/docs/properties/adjust/scale)       |
-| `shape-*`    | trasnform style: 2d, 3d     | [shape](/docs/properties/adjust/shape)       |
-| `skew-*`     | skew element                | [skew](/docs/properties/adjust/skew)         |
+| Utility      | Description                                                                            | Documentation                                |
+| ------------ | -------------------------------------------------------------------------------------- | -------------------------------------------- |
+| `backside-*` | Control backface visibility for 3D transforms and rotations.                           | [backside](/docs/properties/adjust/backside) |
+| `distance-*` | Set translation distance (perspective) for transform positioning, movement and origin. | [distance](/docs/properties/adjust/distance) |
+| `move-*`     | Apply translation transforms to move elements on X, Y, Z axes.                         | [move](/docs/properties/adjust/move)         |
+| `origin-*`   | Define the origin point for transformation operations.                                 | [origin](/docs/properties/adjust/origin)     |
+| `preset-*`   | Use preset, transformation combinations for common effects.                            | [preset](/docs/properties/adjust/preset)     |
+| `rotate-*`   | Apply rotation transforms to elements in 2D or 3D space.                               | [rotate](/docs/properties/adjust/rotate)     |
+| `scale-*`    | Scale elements larger or smaller using transform properties.                           | [scale](/docs/properties/adjust/scale)       |
+| `shape-*`    | Transform style for elements with 2D or 3D effects.                                    | [shape](/docs/properties/adjust/shape)       |
+| `skew-*`     | Apply skew transforms to distort elements along axes.                                  | [skew](/docs/properties/adjust/skew)         |

--- a/apps/docs/src/content/docs/properties/adjust/move.mdx
+++ b/apps/docs/src/content/docs/properties/adjust/move.mdx
@@ -1,12 +1,20 @@
 ---
-title: "Translation Transform | @adjust"
+title: "Move Elements on Axes | @adjust"
 description: "Apply translation transforms to move elements on X, Y, Z axes."
-keywords: ["transform", "translate", "move", "positioned", "css"]
+keywords: ["transform", "translate", "move", "positioned"]
 ---
 
-# move
+# Move Elements on Axes
 
-move element
+Apply translation transforms to move elements on X, Y, Z axes.
+
+Usage:
+
+- `@adjust move-*;`
+- `@adjust move-3d-*;`
+- `@adjust move-x-*;`
+- `@adjust move-y-*;`
+- `@adjust move-z-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/adjust/origin.mdx
+++ b/apps/docs/src/content/docs/properties/adjust/origin.mdx
@@ -1,12 +1,16 @@
 ---
 title: "Transform Origin | @adjust"
 description: "Define the origin point for transformation operations."
-keywords: ["transform", "origin", "transform-origin", "pivot", "css"]
+keywords: ["transform", "origin", "transform-origin", "pivot"]
 ---
 
-# origin
+# Transform Origin
 
-transform origin
+Define the origin point for transformation operations.
+
+Usage:
+
+- `@adjust origin-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/adjust/preset.mdx
+++ b/apps/docs/src/content/docs/properties/adjust/preset.mdx
@@ -1,12 +1,27 @@
 ---
 title: "Transform Presets | @adjust"
-description: "Use preset transformation combinations for common effects."
-keywords: ["transform", "preset", "template", "effects", "css"]
+description: "Use preset, transformation combinations for common effects."
+keywords: ["transform", "preset", "template", "effects"]
 ---
 
-# preset
+# Transform Presets
 
-`transform` property
+Use preset, transformation combinations for common effects.
+
+Usage:
+
+- `@adjust preset;`
+- `@adjust preset-*;`
+
+<Alert variant="warning">
+
+If you are using other `@adjust` utilites, then `preset` utility is requried to
+set the base.
+
+See:
+[Transform Compisition by Variables](/docs/default-styles/variables#transform)
+
+</Alert>
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/adjust/rotate.mdx
+++ b/apps/docs/src/content/docs/properties/adjust/rotate.mdx
@@ -1,12 +1,20 @@
 ---
-title: "Rotation Transform | @adjust"
+title: "Rotate Transform | @adjust"
 description: "Apply rotation transforms to elements in 2D or 3D space."
-keywords: ["transform", "rotate", "rotation", "3d", "css"]
+keywords: ["transform", "rotate", "rotation", "3d"]
 ---
 
-# rotate
+# Rotate Transform
 
-rotate element
+Apply rotation transforms to elements in 2D or 3D space.
+
+Usage:
+
+- `@adjust rotate-*;`
+- `@adjust rotate-3d-*;`
+- `@adjust rotate-x-*;`
+- `@adjust rotate-y-*;`
+- `@adjust rotate-z-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/adjust/scale.mdx
+++ b/apps/docs/src/content/docs/properties/adjust/scale.mdx
@@ -1,12 +1,20 @@
 ---
 title: "Scale Transform | @adjust"
 description: "Scale elements larger or smaller using transform properties."
-keywords: ["transform", "scale", "zoom", "size", "css"]
+keywords: ["transform", "scale", "zoom", "size"]
 ---
 
-# scale
+# Scale Transform
 
-scale element
+Scale elements larger or smaller using transform properties.
+
+Usage:
+
+- `@adjust scale-*;`
+- `@adjust scale-3d-*;`
+- `@adjust scale-x-*;`
+- `@adjust scale-y-*;`
+- `@adjust scale-z-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/adjust/shape.mdx
+++ b/apps/docs/src/content/docs/properties/adjust/shape.mdx
@@ -1,12 +1,18 @@
 ---
-title: "Shape and Perspective Transform | @adjust"
-description: "Transform and reshape elements with perspective effects."
-keywords: ["transform", "shape", "perspective", "skew", "css"]
+title: "Transform Shape | @adjust"
+description: "Transform style for elements with 2D or 3D effects."
+keywords: ["transform", "shape", "perspective", "skew"]
 ---
 
-# shape
+# Transform Shape
 
-trasnform style: 2d, 3d
+Transform style for elements with 2D or 3D effects.
+
+Usage:
+
+- `@adjust shape-*;`
+- `@adjust shape-2d;`
+- `@adjust shape-3d;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/adjust/skew.mdx
+++ b/apps/docs/src/content/docs/properties/adjust/skew.mdx
@@ -1,12 +1,18 @@
 ---
 title: "Skew Transform | @adjust"
 description: "Apply skew transforms to distort elements along axes."
-keywords: ["transform", "skew", "distort", "shear", "css"]
+keywords: ["transform", "skew", "distort", "shear"]
 ---
 
-# skew
+# Skew Transform
 
-skew element
+Apply skew transforms to distort elements along axes.
+
+Usage:
+
+- `@adjust skew-*;`
+- `@adjust skew-x-*;`
+- `@adjust skew-y-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/animate/delay.mdx
+++ b/apps/docs/src/content/docs/properties/animate/delay.mdx
@@ -1,12 +1,16 @@
 ---
 title: "Animation Delay | @animate"
-description: "Control animation start delay timing in milliseconds."
-keywords: ["animation", "delay", "timing", "transition", "css"]
+description: "Control animation start delay timing."
+keywords: ["animation", "delay", "timing", "transition"]
 ---
 
-# delay
+# Animation Delay
 
-delay before an animation starts
+Control animation start delay timing.
+
+Usage:
+
+- `@animate delay-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/animate/direction.mdx
+++ b/apps/docs/src/content/docs/properties/animate/direction.mdx
@@ -1,12 +1,16 @@
 ---
 title: "Animation Direction | @animate"
 description: "Set animation direction to play forward, reverse, or alternate."
-keywords: ["animation", "direction", "playback", "reverse", "css"]
+keywords: ["animation", "direction", "playback", "reverse"]
 ---
 
-# direction
+# Animation Direction
 
-animation direction
+Set animation direction to play forward, reverse, or alternate.
+
+Usage:
+
+- `@animate direction-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/animate/duration.mdx
+++ b/apps/docs/src/content/docs/properties/animate/duration.mdx
@@ -1,12 +1,16 @@
 ---
 title: "Animation Duration | @animate"
-description: "Configure animation duration timing in seconds or milliseconds."
-keywords: ["animation", "duration", "timing", "length", "css"]
+description: "Configure animation duration timing."
+keywords: ["animation", "duration", "timing", "length"]
 ---
 
-# duration
+# Animation Duration
 
-how long an animation takes
+Configure animation duration timing.
+
+Usage:
+
+- `@animate duration-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/animate/enter.mdx
+++ b/apps/docs/src/content/docs/properties/animate/enter.mdx
@@ -1,12 +1,17 @@
 ---
 title: "Entry Animation | @animate"
-description: "Define entry animations for elements appearing on screen."
-keywords: ["animation", "enter", "entrance", "appear", "css"]
+description: "Define entry animations for elements."
+keywords: ["animation", "enter", "entrance", "appear"]
 ---
 
-# enter
+# Entry Animation
 
-enter animation
+Define entry animations for elements appearing on screen.
+
+Usage:
+
+- `@animate enter;`
+- `@animate enter-unset;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/animate/exit.mdx
+++ b/apps/docs/src/content/docs/properties/animate/exit.mdx
@@ -1,12 +1,17 @@
 ---
 title: "Exit Animation | @animate"
-description: "Define exit animations for elements leaving the screen."
-keywords: ["animation", "exit", "leave", "disappear", "css"]
+description: "Define exit animations for elements."
+keywords: ["animation", "exit", "leave", "disappear"]
 ---
 
-# exit
+# Exit Animation
 
-exit animation
+Define exit animations for elements.
+
+Usage:
+
+- `@animate exit;`
+- `@animate exit-unset;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/animate/fade.mdx
+++ b/apps/docs/src/content/docs/properties/animate/fade.mdx
@@ -1,12 +1,23 @@
 ---
 title: "Fade Animation | @animate"
 description: "Apply fade in or fade out animations to elements."
-keywords: ["animation", "fade", "opacity", "transition", "css"]
+keywords: ["animation", "fade", "opacity", "transition"]
 ---
 
-# fade
+# Fade Animation
 
-fade animation
+Apply fade in or fade out animations to elements.
+
+Usage:
+
+- `@animate fade-in-*;`
+- `@animate fade-out-*;`
+
+<Alert variant="warning">
+
+This must be used with `enter` and `exit` animation to take the effect.
+
+</Alert>
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/animate/flow.mdx
+++ b/apps/docs/src/content/docs/properties/animate/flow.mdx
@@ -1,12 +1,16 @@
 ---
 title: "Animation Flow | @animate"
-description: "Control animation flow and sequence behavior."
-keywords: ["animation", "flow", "sequence", "timing", "css"]
+description: "Control animation flow or timing function and sequence behavior."
+keywords: ["animation", "flow", "sequence", "timing"]
 ---
 
-# flow
+# Animation Flow
 
-speed curve of an animation
+Control animation flow or timing function and sequence behavior.
+
+Usage:
+
+- `@animate flow-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/animate/index.mdx
+++ b/apps/docs/src/content/docs/properties/animate/index.mdx
@@ -13,20 +13,20 @@ Animate intent contains element's `animation` related utilities.
 
 Utilities available in `@animate` intent are listed below.
 
-| Utility       | Description                      | Documentation                                   |
-| ------------- | -------------------------------- | ----------------------------------------------- |
-| `delay-*`     | delay before an animation starts | [delay](/docs/properties/animate/delay)         |
-| `direction-*` | animation direction              | [direction](/docs/properties/animate/direction) |
-| `duration-*`  | how long an animation takes      | [duration](/docs/properties/animate/duration)   |
-| `enter-*`     | enter animation                  | [enter](/docs/properties/animate/enter)         |
-| `exit-*`      | exit animation                   | [exit](/docs/properties/animate/exit)           |
-| `fade-*`      | fade animation                   | [fade](/docs/properties/animate/fade)           |
-| `flow-*`      | speed curve of an animation      | [flow](/docs/properties/animate/flow)           |
-| `loop-*`      | iteration count                  | [loop](/docs/properties/animate/loop)           |
-| `mode-*`      | fill mode                        | [mode](/docs/properties/animate/mode)           |
-| `name-*`      | animation name                   | [name](/docs/properties/animate/name)           |
-| `preset-*`    | `animation` property             | [preset](/docs/properties/animate/preset)       |
-| `slide-*`     | slide animation                  | [slide](/docs/properties/animate/slide)         |
-| `spin-*`      | spin animation                   | [spin](/docs/properties/animate/spin)           |
-| `state-*`     | animation play state             | [state](/docs/properties/animate/state)         |
-| `zoom-*`      | zoom animation                   | [zoom](/docs/properties/animate/zoom)           |
+| Utility       | Description                                                      | Documentation                                   |
+| ------------- | ---------------------------------------------------------------- | ----------------------------------------------- |
+| `delay-*`     | Control animation start delay timing.                            | [delay](/docs/properties/animate/delay)         |
+| `direction-*` | Set animation direction to play forward, reverse, or alternate.  | [direction](/docs/properties/animate/direction) |
+| `duration-*`  | Configure animation duration timing.                             | [duration](/docs/properties/animate/duration)   |
+| `enter-*`     | Define entry animations for elements appearing on screen.        | [enter](/docs/properties/animate/enter)         |
+| `exit-*`      | Define exit animations for elements.                             | [exit](/docs/properties/animate/exit)           |
+| `fade-*`      | Apply fade in or fade out animations to elements.                | [fade](/docs/properties/animate/fade)           |
+| `flow-*`      | Control animation flow or timing function and sequence behavior. | [flow](/docs/properties/animate/flow)           |
+| `loop-*`      | Configure animation loop behavior or iteration count.            | [loop](/docs/properties/animate/loop)           |
+| `mode-*`      | Set animation mode for fill behavior and end states.             | [mode](/docs/properties/animate/mode)           |
+| `name-*`      | Apply named animations by specifying keyframe names.             | [name](/docs/properties/animate/name)           |
+| `preset-*`    | Use preset, animation combinations for common effects.           | [preset](/docs/properties/animate/preset)       |
+| `slide-*`     | Apply slide animations to elements moving across screen.         | [slide](/docs/properties/animate/slide)         |
+| `spin-*`      | Apply spinning or rotating animations to elements.               | [spin](/docs/properties/animate/spin)           |
+| `state-*`     | Control animation state transitions and pauses.                  | [state](/docs/properties/animate/state)         |
+| `zoom-*`      | Apply zoom in or zoom out animations to elements.                | [zoom](/docs/properties/animate/zoom)           |

--- a/apps/docs/src/content/docs/properties/animate/loop.mdx
+++ b/apps/docs/src/content/docs/properties/animate/loop.mdx
@@ -1,12 +1,16 @@
 ---
 title: "Animation Loop | @animate"
-description: "Configure animation loop behavior and iteration count."
-keywords: ["animation", "loop", "repeat", "iterations", "css"]
+description: "Configure animation loop behavior or iteration count."
+keywords: ["animation", "loop", "repeat", "iterations"]
 ---
 
-# loop
+# Animation Loop or Iteration Count
 
-iteration count
+Configure animation loop behavior or iteration count.
+
+Usage:
+
+- `@animate loop-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/animate/mode.mdx
+++ b/apps/docs/src/content/docs/properties/animate/mode.mdx
@@ -1,12 +1,16 @@
 ---
-title: "Animation Fill Mode | @animate"
+title: "Animation Mode | @animate"
 description: "Set animation mode for fill behavior and end states."
-keywords: ["animation", "mode", "fill", "forward", "css"]
+keywords: ["animation", "mode", "fill", "forward"]
 ---
 
-# mode
+# Animation Mode
 
-fill mode
+Set animation mode for fill behavior and end states.
+
+Usage:
+
+- `@animate mode-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/animate/name.mdx
+++ b/apps/docs/src/content/docs/properties/animate/name.mdx
@@ -1,12 +1,16 @@
 ---
 title: "Animation Name | @animate"
 description: "Apply named animations by specifying keyframe names."
-keywords: ["animation", "name", "keyframe", "animation-name", "css"]
+keywords: ["animation", "name", "keyframe", "animation-name"]
 ---
 
-# name
+# Animation Name
 
-animation name
+Apply named animations by specifying keyframe names.
+
+Usage:
+
+- `@animate name-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/animate/preset.mdx
+++ b/apps/docs/src/content/docs/properties/animate/preset.mdx
@@ -1,12 +1,16 @@
 ---
 title: "Animation Presets | @animate"
-description: "Use preset animation combinations for common effects."
-keywords: ["animation", "preset", "template", "effects", "css"]
+description: "Use preset, animation combinations for common effects."
+keywords: ["animation", "preset", "template", "effects"]
 ---
 
-# preset
+# Animation Presets
 
-`animation` property
+Use preset, animation combinations for common effects.
+
+Usage:
+
+- `@animate preset-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/animate/slide.mdx
+++ b/apps/docs/src/content/docs/properties/animate/slide.mdx
@@ -1,12 +1,23 @@
 ---
 title: "Slide Animation | @animate"
 description: "Apply slide animations to elements moving across screen."
-keywords: ["animation", "slide", "transform", "movement", "css"]
+keywords: ["animation", "slide", "transform", "movement"]
 ---
 
-# slide
+# Slide Animation
 
-slide animation
+Apply slide animations to elements moving across screen.
+
+Usage:
+
+- `@animate slide-in-from-*;`
+- `@animate slide-out-to-*;`
+
+<Alert variant="warning">
+
+This must be used with `enter` and `exit` animation to take the effect.
+
+</Alert>
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/animate/spin.mdx
+++ b/apps/docs/src/content/docs/properties/animate/spin.mdx
@@ -1,12 +1,23 @@
 ---
 title: "Spin Animation | @animate"
 description: "Apply spinning or rotating animations to elements."
-keywords: ["animation", "spin", "rotate", "circular", "css"]
+keywords: ["animation", "spin", "rotate", "circular"]
 ---
 
-# spin
+# Spin Animation
 
-spin animation
+Apply spinning or rotating animations to elements.
+
+Usage:
+
+- `@animate spin-in-*;`
+- `@animate spin-out-*;`
+
+<Alert variant="warning">
+
+This must be used with `enter` and `exit` animation to take the effect.
+
+</Alert>
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/animate/state.mdx
+++ b/apps/docs/src/content/docs/properties/animate/state.mdx
@@ -1,12 +1,18 @@
 ---
-title: "Animation State | @animate"
+title: "Animation Play State | @animate"
 description: "Control animation state transitions and pauses."
-keywords: ["animation", "state", "pause", "running", "css"]
+keywords: ["animation", "state", "pause", "running"]
 ---
 
-# state
+# Animation Play State
 
-animation play state
+Control animation state transitions and pauses.
+
+Usage:
+
+- `@animate state-*;`
+- `@animate state-paused;`
+- `@animate state-playing;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/animate/zoom.mdx
+++ b/apps/docs/src/content/docs/properties/animate/zoom.mdx
@@ -1,12 +1,23 @@
 ---
 title: "Zoom Animation | @animate"
 description: "Apply zoom in or zoom out animations to elements."
-keywords: ["animation", "zoom", "scale", "magnify", "css"]
+keywords: ["animation", "zoom", "scale", "magnify"]
 ---
 
-# zoom
+# Zoom Animation
 
-zoom animation
+Apply zoom in or zoom out animations to elements.
+
+Usage:
+
+- `@animate zoom-in-*;`
+- `@animate zoom-out-*;`
+
+<Alert variant="warning">
+
+This must be used with `enter` and `exit` animation to take the effect.
+
+</Alert>
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/bg/attachment.mdx
+++ b/apps/docs/src/content/docs/properties/bg/attachment.mdx
@@ -1,12 +1,16 @@
 ---
 title: "Background Attachment | @bg"
 description: "Control background attachment behavior, fixed or scroll."
-keywords: ["background", "attachment", "scroll", "fixed", "css"]
+keywords: ["background", "attachment", "scroll", "fixed"]
 ---
 
-# attachment
+# Background Attachment
 
-background attachment
+Control background attachment behavior, fixed or scroll.
+
+Usage:
+
+- `@bg attachment-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/bg/blend.mdx
+++ b/apps/docs/src/content/docs/properties/bg/blend.mdx
@@ -1,12 +1,16 @@
 ---
 title: "Background Blend Mode | @bg"
-description: "Set background blend mode for layering effects."
-keywords: ["background", "blend", "mix-blend-mode", "compositing", "css"]
+description: "Set background-blend-mode for layering effects."
+keywords: ["background", "blend", "mix-blend-mode", "compositing"]
 ---
 
-# blend
+# Background Blend Mode
 
-blending between multiple background layers
+Set `background-blend-mode` for layering effects.
+
+Usage:
+
+- `@bg blend-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/bg/clip.mdx
+++ b/apps/docs/src/content/docs/properties/bg/clip.mdx
@@ -1,12 +1,16 @@
 ---
 title: "Background Clip Area | @bg"
-description: "Define background clip area within element."            
-keywords: ["background", "clip", "padding", "border", "css"]
+description: "Define background clip area within element."
+keywords: ["background", "clip", "padding", "border"]
 ---
 
-# clip
+# Background Clip Area
 
-background clip
+Define background clip area within element.
+
+Usage:
+
+- `@bg clip-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/bg/color.mdx
+++ b/apps/docs/src/content/docs/properties/bg/color.mdx
@@ -1,12 +1,16 @@
 ---
 title: "Background Color | @bg"
 description: "Apply background color to elements."
-keywords: ["background", "color", "background-color", "styling", "css"]
+keywords: ["background", "color", "background-color", "styling"]
 ---
 
-# color
+# Background Color
 
-background color
+Apply background color to elements.
+
+Usage:
+
+- `@bg color-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/bg/gradient.mdx
+++ b/apps/docs/src/content/docs/properties/bg/gradient.mdx
@@ -1,12 +1,28 @@
 ---
-title: "Background Gradient | @bg"
+title: "Background Gradient Colors | @bg"
 description: "Apply gradient backgrounds with linear or radial patterns."
-keywords: ["background", "gradient", "linear", "radial", "css"]
+keywords: ["background", "gradient", "linear", "radial"]
 ---
 
-# gradient
+# Background Gradient Colors
 
-linear, radial, conic gradients
+Apply gradient backgrounds with linear, radial and other patterns.
+
+Usage:
+
+- `@bg gradient-*;`
+- `@bg gradient-linear-*;`
+- `@bg gradient-radial-*;`
+- `@bg gradient-conic-*;`
+
+<Alert variant="danger">
+
+Gradient color uses `background-image` property.
+
+So, if you are using `@bg img-*;` then conflict will be created. You need to
+choose a stratagey to work with both.
+
+</Alert>
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/bg/img.mdx
+++ b/apps/docs/src/content/docs/properties/bg/img.mdx
@@ -1,12 +1,30 @@
 ---
 title: "Background Image | @bg"
-description: "Set background images from URLs or data URIs."
-keywords: ["background", "image", "background-image", "url", "css"]
+description:
+  "Set background images with position, size, origin and other styles."
+keywords: ["background", "image", "background-image", "url"]
 ---
 
-# image
+# Background Image
 
-background image, origin, position, repeat and size
+Set background images with position, size, origin and other styles.
+
+Usage:
+
+- `@bg img-*;`
+- `@bg img-origin-*;`
+- `@bg img-position-*;`
+- `@bg img-repeat-*;`
+- `@bg img-size-*;`
+
+<Alert variant="danger">
+
+Gradient color also uses `background-image` property.
+
+So, if you are using `@bg gradient-*;` then conflict will be created. You need
+to choose a stratagey to work with both.
+
+</Alert>
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/bg/index.mdx
+++ b/apps/docs/src/content/docs/properties/bg/index.mdx
@@ -12,11 +12,11 @@ BG intent contains element's `background` related utilities.
 
 Utilities available in `@bg` intent are listed below.
 
-| Utility        | Description                                         | Documentation                                |
-| -------------- | --------------------------------------------------- | -------------------------------------------- |
-| `attachment-*` | background attachment                               | [attachment](/docs/properties/bg/attachment) |
-| `blend-*`      | blending between multiple background layers         | [blend](/docs/properties/bg/blend)           |
-| `clip-*`       | background clip                                     | [clip](/docs/properties/bg/clip)             |
-| `color-*`      | background color                                    | [color](/docs/properties/bg/color)           |
-| `gradient-*`   | linear, radial, conic gradients                     | [gradient](/docs/properties/bg/gradient)     |
-| `img-*`        | background image, origin, position, repeat and size | [image](/docs/properties/bg/image)           |
+| Utility        | Description                                                         | Documentation                                |
+| -------------- | ------------------------------------------------------------------- | -------------------------------------------- |
+| `attachment-*` | Control background attachment behavior, fixed or scroll.            | [attachment](/docs/properties/bg/attachment) |
+| `blend-*`      | Set `background-blend-mode` for layering effects.                   | [blend](/docs/properties/bg/blend)           |
+| `clip-*`       | Define background clip area within element.                         | [clip](/docs/properties/bg/clip)             |
+| `color-*`      | Apply background color to elements.                                 | [color](/docs/properties/bg/color)           |
+| `gradient-*`   | Apply gradient backgrounds with linear, radial and other patterns.  | [gradient](/docs/properties/bg/gradient)     |
+| `img-*`        | Set background images with position, size, origin and other styles. | [img](/docs/properties/bg/img)               |

--- a/apps/docs/src/content/docs/properties/bg/meta.json
+++ b/apps/docs/src/content/docs/properties/bg/meta.json
@@ -3,5 +3,5 @@
 	"name": "index",
 	"label": "@bg",
 	"title": "bg (a.k.a. background) intent",
-	"items": ["attachment", "blend", "clip", "color", "gradient", "image"]
+	"items": ["attachment", "blend", "clip", "color", "gradient", "img"]
 }

--- a/apps/docs/src/content/docs/properties/border/color.mdx
+++ b/apps/docs/src/content/docs/properties/border/color.mdx
@@ -1,12 +1,26 @@
 ---
 title: "Border Color | @border"
 description: "Apply border colors to element borders."
-keywords: ["border", "color", "border-color", "outline", "css"]
+keywords: ["border", "color", "border-color", "outline"]
 ---
 
-# color
+# Border Color
 
-border color
+Apply border colors to element borders.
+
+Usage:
+
+- `@border color-*;`
+- `@border color-top-*;`
+- `@border color-right-*;`
+- `@border color-bottom-*;`
+- `@border color-left-*;`
+- `@border color-x-*;`
+- `@border color-y-*;`
+- `@border color-bl-*;`
+- `@border color-bls-*;`
+- `@border color-bi-*;`
+- `@border color-bis-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/border/index.mdx
+++ b/apps/docs/src/content/docs/properties/border/index.mdx
@@ -12,9 +12,9 @@ Border intent contains element's `border` related utilities.
 
 Utilities available in `@border` intent are listed below.
 
-| Utility     | Description                     | Documentation                              |
-| ----------- | ------------------------------- | ------------------------------------------ |
-| `color-*`   | border color                    | [color](/docs/properties/border/color)     |
-| `rounded-*` | border radius                   | [rounded](/docs/properties/border/rounded) |
-| `style-*`   | border style like solid, dashed | [style](/docs/properties/border/style)     |
-| `thick-*`   | border thickness                | [thick](/docs/properties/border/thick)     |
+| Utility     | Description                                               | Documentation                              |
+| ----------- | --------------------------------------------------------- | ------------------------------------------ |
+| `color-*`   | Apply border colors to element borders.                   | [color](/docs/properties/border/color)     |
+| `rounded-*` | Set border radius for rounded corners on elements.        | [rounded](/docs/properties/border/rounded) |
+| `style-*`   | Define border styles like solid, dashed, dotted and more. | [style](/docs/properties/border/style)     |
+| `thick-*`   | Control border width or thickness for styling.            | [thick](/docs/properties/border/thick)     |

--- a/apps/docs/src/content/docs/properties/border/rounded.mdx
+++ b/apps/docs/src/content/docs/properties/border/rounded.mdx
@@ -1,12 +1,24 @@
 ---
 title: "Border Radius | @border"
 description: "Set border radius for rounded corners on elements."
-keywords: ["border", "rounded", "border-radius", "corners", "css"]
+keywords: ["border", "rounded", "border-radius", "corners"]
 ---
 
-# rounded
+# Border Radius
 
-border radius
+Set border radius for rounded corners on elements.
+
+Usage:
+
+- `@border rounded-*;`
+- `@border rounded-top-*;`
+- `@border rounded-right-*;`
+- `@border rounded-bottom-*;`
+- `@border rounded-left-*;`
+- `@border rounded-tl-*;`
+- `@border rounded-tr-*;`
+- `@border rounded-bl-*;`
+- `@border rounded-br-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/border/style.mdx
+++ b/apps/docs/src/content/docs/properties/border/style.mdx
@@ -1,12 +1,26 @@
 ---
 title: "Border Style | @border"
-description: "Define border styles like solid, dashed, dotted."
-keywords: ["border", "style", "border-style", "stroke", "css"]
+description: "Define border styles like solid, dashed, dotted and more."
+keywords: ["border", "style", "border-style", "stroke"]
 ---
 
-# style
+# Border Style
 
-border style like solid, dashed
+Define border styles like solid, dashed, dotted and more.
+
+Usage:
+
+- `@border style-*;`
+- `@border style-top-*;`
+- `@border style-right-*;`
+- `@border style-bottom-*;`
+- `@border style-left-*;`
+- `@border style-x-*;`
+- `@border style-y-*;`
+- `@border style-bl-*;`
+- `@border style-bls-*;`
+- `@border style-bi-*;`
+- `@border style-bis-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/border/thick.mdx
+++ b/apps/docs/src/content/docs/properties/border/thick.mdx
@@ -1,12 +1,26 @@
 ---
-title: "Border Width | @border"
-description: "Control border width properties for styling."
-keywords: ["border", "thick", "border-width", "width", "css"]
+title: "Border Thickness (Width) | @border"
+description: "Control border width or thickness for styling."
+keywords: ["border", "thick", "border-width", "width"]
 ---
 
-# thick
+# Border Thickness (Width)
 
-border thickness
+Control border width or thickness for styling.
+
+Usage:
+
+- `@border thick-*;`
+- `@border thick-top-*;`
+- `@border thick-right-*;`
+- `@border thick-bottom-*;`
+- `@border thick-left-*;`
+- `@border thick-x-*;`
+- `@border thick-y-*;`
+- `@border thick-bl-*;`
+- `@border thick-bls-*;`
+- `@border thick-bi-*;`
+- `@border thick-bis-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/filter/backdrop/blur.mdx
+++ b/apps/docs/src/content/docs/properties/filter/backdrop/blur.mdx
@@ -1,12 +1,16 @@
 ---
-title: "Backdrop Grayscale Filter | @filter"
-description: "Apply backdrop grayscale filter to elements."
-keywords: ["filter", "backdrop", "grayscale", "effect", "css"]
+title: "Backdrop Blur Filter | @filter"
+description: "Apply backdrop blur filter effect to elements."
+keywords: ["filter", "backdrop", "blur", "effect"]
 ---
 
-# backdrop gray
+# Backdrop Blur Filter
 
-grayscale backdrop filter
+Apply backdrop blur filter effect to elements.
+
+Usage:
+
+- `@filter backdrop-blur-*;`
 
 <Alert variant="info">
 
@@ -28,9 +32,10 @@ const shilpConfig = {
 	properties: {
 		filter: {
 			backdrop: {
-				gray: {
-					property: "backdrop-filter: grayscale(<v>)<i>;",
-					themeKey: "fractions",
+				blur: {
+					property: "backdrop-filter: blur(<v>)<i>;",
+					resolve: "spacing",
+					themeKey: "blur",
 					values: {},
 				},
 			},

--- a/apps/docs/src/content/docs/properties/filter/backdrop/bright.mdx
+++ b/apps/docs/src/content/docs/properties/filter/backdrop/bright.mdx
@@ -1,12 +1,16 @@
 ---
-title: "Backdrop Saturate Filter | @filter"
-description: "Adjust backdrop saturation filter values."
-keywords: ["filter", "backdrop", "saturate", "color", "css"]
+title: "Backdrop Brightness Filter | @filter"
+description: "Adjust backdrop brightness filter effects."
+keywords: ["filter", "backdrop", "brightness", "effect"]
 ---
 
-# backdrop saturate
+# Backdrop Brightness Filter
 
-saturatation backdrop filter
+Adjust backdrop brightness filter effects.
+
+Usage:
+
+- `@filter backdrop-bright-*;`
 
 <Alert variant="info">
 
@@ -28,8 +32,8 @@ const shilpConfig = {
 	properties: {
 		filter: {
 			backdrop: {
-				saturate: {
-					property: "backdrop-filter: saturate(<v>)<i>;",
+				bright: {
+					property: "backdrop-filter: brightness(<v>)<i>;",
 					themeKey: "fractions",
 					values: {},
 				},

--- a/apps/docs/src/content/docs/properties/filter/backdrop/contrast.mdx
+++ b/apps/docs/src/content/docs/properties/filter/backdrop/contrast.mdx
@@ -1,12 +1,16 @@
 ---
-title: "Backdrop Sepia Filter | @filter"
-description: "Apply backdrop sepia tone filter effect."
-keywords: ["filter", "backdrop", "sepia", "tone", "css"]
+title: "Backdrop Contrast Filter | @filter"
+description: "Control backdrop contrast filter effect."
+keywords: ["filter", "backdrop", "contrast", "effect"]
 ---
 
-# backdrop sepia
+# Backdrop Contrast Filter
 
-sepia backdrop filter
+Control backdrop contrast filter effect.
+
+Usage:
+
+- `@filter backdrop-contrast-*;`
 
 <Alert variant="info">
 
@@ -28,8 +32,8 @@ const shilpConfig = {
 	properties: {
 		filter: {
 			backdrop: {
-				sepia: {
-					property: "backdrop-filter: sepia(<v>)<i>;",
+				contrast: {
+					property: "backdrop-filter: contrast(<v>)<i>;",
 					themeKey: "fractions",
 					values: {},
 				},

--- a/apps/docs/src/content/docs/properties/filter/backdrop/gray.mdx
+++ b/apps/docs/src/content/docs/properties/filter/backdrop/gray.mdx
@@ -1,12 +1,16 @@
 ---
-title: "Backdrop Hue Rotation Filter | @filter"
-description: "Adjust backdrop hue rotation filter values."
-keywords: ["filter", "backdrop", "hue", "color", "css"]
+title: "Backdrop Grayscale Filter | @filter"
+description: "Apply backdrop grayscale filter to elements."
+keywords: ["filter", "backdrop", "grayscale", "effect"]
 ---
 
-# backdrop hue
+# Backdrop Grayscale Filter
 
-rotate hue backdrop filter
+Apply backdrop grayscale filter to elements.
+
+Usage:
+
+- `@filter backdrop-gray-*;`
 
 <Alert variant="info">
 
@@ -28,9 +32,9 @@ const shilpConfig = {
 	properties: {
 		filter: {
 			backdrop: {
-				hue: {
-					property: "backdrop-filter: hue-rotate(<v>)<i>;",
-					themeKey: "angles",
+				gray: {
+					property: "backdrop-filter: grayscale(<v>)<i>;",
+					themeKey: "fractions",
 					values: {},
 				},
 			},

--- a/apps/docs/src/content/docs/properties/filter/backdrop/hue.mdx
+++ b/apps/docs/src/content/docs/properties/filter/backdrop/hue.mdx
@@ -1,12 +1,16 @@
 ---
-title: "Backdrop Invert Filter | @filter"
-description: "Invert backdrop colors with filter effect."
-keywords: ["filter", "backdrop", "invert", "color", "css"]
+title: "Backdrop Hue Rotate Filter | @filter"
+description: "Adjust backdrop hue rotation filter effects."
+keywords: ["filter", "backdrop", "hue", "color"]
 ---
 
-# backdrop invert
+# Backdrop Hue Rotate Filter
 
-invert backdrop filter
+Adjust backdrop hue rotation filter effects.
+
+Usage:
+
+- `@filter backdrop-hue-*;`
 
 <Alert variant="info">
 
@@ -28,12 +32,10 @@ const shilpConfig = {
 	properties: {
 		filter: {
 			backdrop: {
-				invert: {
-					property: "backdrop-filter: invert(<v>)<i>;",
-					values: {
-						DEFAULT: 1,
-						none: 0,
-					},
+				hue: {
+					property: "backdrop-filter: hue-rotate(<v>)<i>;",
+					themeKey: "angles",
+					values: {},
 				},
 			},
 		},

--- a/apps/docs/src/content/docs/properties/filter/backdrop/index.mdx
+++ b/apps/docs/src/content/docs/properties/filter/backdrop/index.mdx
@@ -1,12 +1,37 @@
 ---
 title: "Backdrop Filter | @filter"
-description: "Apply backdrop filter effects to elements."
-keywords: ["filter", "backdrop", "effect", "visual", "css"]
+description:
+  "Apply backdrop filter effects to elements. Blur, Brightness, grayscale and
+  many more."
+keywords:
+  [
+    "@filter",
+    "filter",
+    "backdrop",
+    "templates",
+    "effect",
+    "visual",
+    "css",
+    "blur",
+    "brightness",
+    "grayscale",
+    "contrast",
+    "hue-rotate",
+    "invert",
+    "opacity",
+    "saturation",
+    "sepia",
+    "drop-shadow",
+  ]
 ---
 
-# backdrop
+# Backdrop Filter
 
-`backdrop-filter` property
+Apply backdrop filter effects to elements.
+
+Usage:
+
+- `@filter backdrop-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/filter/backdrop/invert.mdx
+++ b/apps/docs/src/content/docs/properties/filter/backdrop/invert.mdx
@@ -1,12 +1,16 @@
 ---
-title: "Backdrop Contrast Filter | @filter"
-description: "Control backdrop contrast filter effect."
-keywords: ["filter", "backdrop", "contrast", "effect", "css"]
+title: "Backdrop Invert Filter | @filter"
+description: "Invert backdrop colors with filter effect."
+keywords: ["filter", "backdrop", "invert", "color"]
 ---
 
-# backdrop contrast
+# Backdrop Invert Filter
 
-contrast backdrop filter
+Invert backdrop colors with filter effect.
+
+Usage:
+
+- `@filter backdrop-invert-*;`
 
 <Alert variant="info">
 
@@ -27,11 +31,13 @@ const shilpConfig = {
 
 	properties: {
 		filter: {
-			contrast: {
-				contrast: {
-					property: "backdrop-filter: contrast(<v>)<i>;",
-					themeKey: "fractions",
-					values: {},
+			backdrop: {
+				invert: {
+					property: "backdrop-filter: invert(<v>)<i>;",
+					values: {
+						DEFAULT: 1,
+						none: 0,
+					},
 				},
 			},
 		},

--- a/apps/docs/src/content/docs/properties/filter/backdrop/meta.json
+++ b/apps/docs/src/content/docs/properties/filter/backdrop/meta.json
@@ -1,0 +1,48 @@
+{
+	"page": true,
+	"name": "index",
+	"label": "backdrop",
+	"title": "backdrop filter",
+	"items": [
+		{
+			"name": "blur",
+			"title": "backdrop blur"
+		},
+		{
+			"name": "bright",
+			"title": "backdrop brightness"
+		},
+		{
+			"name": "contrast",
+			"title": "backdrop contrast"
+		},
+		{
+			"name": "gray",
+			"title": "backdrop grayscale"
+		},
+		{
+			"name": "hue",
+			"title": "backdrop hue rotate"
+		},
+		{
+			"name": "invert",
+			"title": "backdrop invert"
+		},
+		{
+			"name": "opacity",
+			"title": "backdrop opacity"
+		},
+		{
+			"name": "saturate",
+			"title": "backdrop saturation"
+		},
+		{
+			"name": "sepia",
+			"title": "backdrop sepia"
+		},
+		{
+			"name": "shadow",
+			"title": "backdrop shadow"
+		}
+	]
+}

--- a/apps/docs/src/content/docs/properties/filter/backdrop/opacity.mdx
+++ b/apps/docs/src/content/docs/properties/filter/backdrop/opacity.mdx
@@ -1,12 +1,16 @@
 ---
-title: "Backdrop Brightness Filter | @filter"
-description: "Adjust backdrop brightness filter values."
-keywords: ["filter", "backdrop", "brightness", "effect", "css"]
+title: "Backdrop Opacity Filter | @filter"
+description: "Control backdrop opacity filter effect."
+keywords: ["filter", "backdrop", "opacity", "transparency"]
 ---
 
-# backdrop bright
+# Backdrop Opacity Filter
 
-brightness backdrop filter
+Control backdrop opacity filter effect.
+
+Usage:
+
+- `@filter backdrop-opacity-*;`
 
 <Alert variant="info">
 
@@ -28,8 +32,8 @@ const shilpConfig = {
 	properties: {
 		filter: {
 			backdrop: {
-				bright: {
-					property: "backdrop-filter: brightness(<v>)<i>;",
+				opacity: {
+					property: "backdrop-filter: opacity(<v>)<i>;",
 					themeKey: "fractions",
 					values: {},
 				},

--- a/apps/docs/src/content/docs/properties/filter/backdrop/saturate.mdx
+++ b/apps/docs/src/content/docs/properties/filter/backdrop/saturate.mdx
@@ -1,12 +1,16 @@
 ---
-title: "Backdrop Opacity Filter | @filter"
-description: "Control backdrop opacity filter effect."
-keywords: ["filter", "backdrop", "opacity", "transparency", "css"]
+title: "Backdrop Saturation Filter | @filter"
+description: "Adjust backdrop saturation filter values."
+keywords: ["filter", "backdrop", "saturate", "color"]
 ---
 
-# backdrop opacity
+# Backdrop Saturation Filter
 
-opacity backdrop filter
+Adjust backdrop saturation filter values.
+
+Usage:
+
+- `@filter backdrop-saturate-*;`
 
 <Alert variant="info">
 
@@ -28,8 +32,8 @@ const shilpConfig = {
 	properties: {
 		filter: {
 			backdrop: {
-				opacity: {
-					property: "backdrop-filter: opacity(<v>)<i>;",
+				saturate: {
+					property: "backdrop-filter: saturate(<v>)<i>;",
 					themeKey: "fractions",
 					values: {},
 				},

--- a/apps/docs/src/content/docs/properties/filter/backdrop/sepia.mdx
+++ b/apps/docs/src/content/docs/properties/filter/backdrop/sepia.mdx
@@ -1,12 +1,16 @@
 ---
-title: "Line Height | @text"
-description: "Set line height for text spacing."
-keywords: ["text", "line-height", "spacing", "typography", "css"]
+title: "Backdrop Sepia Filter | @filter"
+description: "Apply backdrop sepia tone filter effect."
+keywords: ["filter", "backdrop", "sepia", "tone"]
 ---
 
-# line height
+# Backdrop Sepia Filter
 
-controls text column sizing algorithm
+Apply backdrop sepia tone filter effect.
+
+Usage:
+
+- `@filter backdrop-sepia-*;`
 
 <Alert variant="info">
 
@@ -26,17 +30,12 @@ const shilpConfig = {
 	source: "react",
 
 	properties: {
-		text: {
-			h: {
-				property: "line-height: <v><i>;",
-				values: {
-					normal: 1,
-					xs: 1.25,
-					sm: 1.375,
-					base: 1.5,
-					md: 1.625,
-					lg: 1.75,
-					xl: 2,
+		filter: {
+			backdrop: {
+				sepia: {
+					property: "backdrop-filter: sepia(<v>)<i>;",
+					themeKey: "fractions",
+					values: {},
 				},
 			},
 		},

--- a/apps/docs/src/content/docs/properties/filter/backdrop/shadow.mdx
+++ b/apps/docs/src/content/docs/properties/filter/backdrop/shadow.mdx
@@ -1,12 +1,17 @@
 ---
 title: "Backdrop Shadow Filter | @filter"
-description: "Add backdrop shadow filter effects."
-keywords: ["filter", "backdrop", "shadow", "depth", "css"]
+description: "Add backdrop shadow (drop-shadow) filter effects."
+keywords: ["filter", "backdrop", "shadow", "depth"]
 ---
 
-# backdrop shadow
+# Backdrop Shadow Filter
 
-backdrop shadow filter
+Add backdrop shadow (`drop-shadow`) filter effects.
+
+Usage:
+
+- `@filter backdrop-shadow-*;`
+- `@filter backdrop-shadow-color-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/filter/blur.mdx
+++ b/apps/docs/src/content/docs/properties/filter/blur.mdx
@@ -1,12 +1,16 @@
 ---
 title: "Blur Filter | @filter"
 description: "Apply blur filter effect to element."
-keywords: ["filter", "blur", "effect", "visual", "css"]
+keywords: ["filter", "blur", "effect", "visual"]
 ---
 
-# blur
+# Blur Filter
 
-blur filter
+Apply blur filter effect to element.
+
+Usage:
+
+- `@filter blur-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/filter/bright.mdx
+++ b/apps/docs/src/content/docs/properties/filter/bright.mdx
@@ -1,12 +1,16 @@
 ---
 title: "Brightness Filter | @filter"
 description: "Adjust brightness filter effect on elements."
-keywords: ["filter", "brightness", "effect", "visual", "css"]
+keywords: ["filter", "brightness", "effect", "visual"]
 ---
 
-# brightness
+# Brightness Filter
 
-brightness filter
+Adjust brightness filter effect on elements.
+
+Usage:
+
+- `@filter bright-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/filter/contrast.mdx
+++ b/apps/docs/src/content/docs/properties/filter/contrast.mdx
@@ -1,12 +1,16 @@
 ---
 title: "Contrast Filter | @filter"
 description: "Control contrast filter effect on elements."
-keywords: ["filter", "contrast", "effect", "visual", "css"]
+keywords: ["filter", "contrast", "effect", "visual"]
 ---
 
-# contrast
+# Contrast Filter
 
-contrast filter
+Control contrast filter effect on elements.
+
+Usage:
+
+- `@filter contrast-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/filter/gray.mdx
+++ b/apps/docs/src/content/docs/properties/filter/gray.mdx
@@ -1,12 +1,16 @@
 ---
 title: "Grayscale Filter | @filter"
 description: "Apply grayscale filter to convert colors to gray."
-keywords: ["filter", "grayscale", "effect", "color", "css"]
+keywords: ["filter", "grayscale", "effect", "color"]
 ---
 
-# gray
+# Grayscale Filter
 
-grayscale filter
+Apply grayscale filter to convert colors to gray.
+
+Usage:
+
+- `@filter gray-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/filter/hue.mdx
+++ b/apps/docs/src/content/docs/properties/filter/hue.mdx
@@ -1,12 +1,16 @@
 ---
-title: "Hue Rotation | @filter"
+title: "Hue Rotate Filter | @filter"
 description: "Adjust hue rotation filter on elements."
-keywords: ["filter", "hue", "color", "rotation", "css"]
+keywords: ["filter", "hue", "color", "rotation"]
 ---
 
-# hue
+# Hue Rotate Filter
 
-hue rotate filter
+Adjust hue rotation filter on elements.
+
+Usage:
+
+- `@filter hue-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/filter/index.mdx
+++ b/apps/docs/src/content/docs/properties/filter/index.mdx
@@ -1,10 +1,25 @@
 ---
 title: "Filter Intent - Visual Effects"
 description:
-  "Visual effects with @filter intent. Blur, brightness, contrast, grayscale,
-  and backdrop filters."
+  "Visual effects with @filter intent. Blur, brightness, grayscale, backdrop
+  filters and many more."
 keywords:
-  ["@filter", "filter", "Visual effects", "blur", "backdrop", "brightness"]
+  [
+    "@filter",
+    "filter",
+    "Visual effects",
+    "blur",
+    "backdrop",
+    "brightness",
+    "grayscale",
+    "contrast",
+    "hue-rotate",
+    "invert",
+    "opacity",
+    "saturation",
+    "sepia",
+    "drop-shadow",
+  ]
 ---
 
 # Filter Intent Overview
@@ -14,27 +29,44 @@ CSS properties.
 
 Utilities available in `@filter` intent are listed below.
 
-| Utility               | Description                  | Documentation                                                    |
-| --------------------- | ---------------------------- | ---------------------------------------------------------------- |
-| `blur-*`              | blur filter                  | [blur](/docs/properties/filter/blur)                             |
-| `bright-*`            | brightness filter            | [brightness](/docs/properties/filter/bright)                     |
-| `contrast-*`          | contrast filter              | [contrast](/docs/properties/filter/contrast)                     |
-| `gray-*`              | grayscale filter             | [grayscale](/docs/properties/filter/gray)                        |
-| `hue-*`               | hue rotate filter            | [hue](/docs/properties/filter/hue)                               |
-| `invert-*`            | invert filter                | [invert](/docs/properties/filter/invert)                         |
-| `opacity-*`           | opacity filter               | [opacity](/docs/properties/filter/opacity)                       |
-| `saturate-*`          | saturatation filter          | [saturation](/docs/properties/filter/saturate)                   |
-| `sepia-*`             | sepia filter                 | [sepia](/docs/properties/filter/sepia)                           |
-| `shadow-*`            | drop shadow filter           | [shadow](/docs/properties/filter/shadow)                         |
-| `preset-*`            | `filter` property            | [preset](/docs/properties/filter/preset)                         |
-| `backdrop-*`          | `backdrop-filter` property   | [backdrop](/docs/properties/filter/backdrop)                     |
-| `backdrop-blur-*`     | blur backdrop filter         | [backdrop blur](/docs/properties/filter/backdrop-blur)           |
-| `backdrop-bright-*`   | brightness backdrop filter   | [backdrop bright](/docs/properties/filter/backdrop-bright)       |
-| `backdrop-contrast-*` | contrast backdrop filter     | [backdrop contrast](/docs/properties/filter/backdrop-contrast)   |
-| `backdrop-gray-*`     | grayscale backdrop filter    | [backdrop gray](/docs/properties/filter/backdrop-gray)           |
-| `backdrop-hue-*`      | rotate hue backdrop filter   | [backdrop hue](/docs/properties/filter/backdrop-hue)             |
-| `backdrop-invert-*`   | invert backdrop filter       | [backdrop invert](/docs/properties/filter/backdrop-invert)       |
-| `backdrop-opacity-*`  | opacity backdrop filter      | [backdrop opacity](/docs/properties/filter/backdrop-opacity)     |
-| `backdrop-saturate-*` | saturatation backdrop filter | [backdrop saturation](/docs/properties/filter/backdrop-saturate) |
-| `backdrop-sepia-*`    | sepia backdrop filter        | [backdrop sepia](/docs/properties/filter/backdrop-sepia)         |
-| `backdrop-shadow-*`   | backdrop shadow filter       | [backdrop shadow](/docs/properties/filter/backdrop-shadow)       |
+---
+
+<section>
+
+## filter
+
+| Utility      | Description                                            | Documentation                                |
+| ------------ | ------------------------------------------------------ | -------------------------------------------- |
+| `blur-*`     | Apply blur filter effect to elements.                  | [blur](/docs/properties/filter/blur)         |
+| `bright-*`   | Adjust brightness filter effects.                      | [bright](/docs/properties/filter/bright)     |
+| `contrast-*` | Control contrast filter effect.                        | [contrast](/docs/properties/filter/contrast) |
+| `gray-*`     | Apply grayscale filter to elements.                    | [gray](/docs/properties/filter/gray)         |
+| `hue-*`      | Adjust hue rotation filter on elements.                | [hue](/docs/properties/filter/hue)           |
+| `invert-*`   | Invert colors with filter effect.                      | [invert](/docs/properties/filter/invert)     |
+| `opacity-*`  | Control element opacity filter effect.                 | [opacity](/docs/properties/filter/opacity)   |
+| `preset-*`   | Use preset, filter combinations for common effects.    | [preset](/docs/properties/filter/preset)     |
+| `saturate-*` | Adjust saturation filter on element colors.            | [saturate](/docs/properties/filter/saturate) |
+| `sepia-*`    | Apply sepia tone filter effect to elements.            | [sepia](/docs/properties/filter/sepia)       |
+| `shadow-*`   | Add shadow (`drop-shadow`) filter effects to elements. | [shadow](/docs/properties/filter/shadow)     |
+
+</section>
+
+<section>
+
+## backdrop-filter
+
+| Utility               | Description                                         | Documentation                                                  |
+| --------------------- | --------------------------------------------------- | -------------------------------------------------------------- |
+| `backdrop-*`          | Apply backdrop filter effects to elements.          | [backdrop](/docs/properties/filter/backdrop)                   |
+| `backdrop-blur-*`     | Apply backdrop blur filter effect to elements.      | [backdrop blur](/docs/properties/filter/backdrop/blur)         |
+| `backdrop-bright-*`   | Adjust backdrop brightness filter effects.          | [backdrop bright](/docs/properties/filter/backdrop/bright)     |
+| `backdrop-contrast-*` | Control backdrop contrast filter effect.            | [backdrop contrast](/docs/properties/filter/backdrop/contrast) |
+| `backdrop-gray-*`     | Apply backdrop grayscale filter to elements.        | [backdrop gray](/docs/properties/filter/backdrop/gray)         |
+| `backdrop-hue-*`      | Adjust backdrop hue rotation filter effects.        | [backdrop hue](/docs/properties/filter/backdrop/hue)           |
+| `backdrop-invert-*`   | Invert backdrop colors with filter effect.          | [backdrop invert](/docs/properties/filter/backdrop/invert)     |
+| `backdrop-opacity-*`  | Control backdrop opacity filter effect.             | [backdrop opacity](/docs/properties/filter/backdrop/opacity)   |
+| `backdrop-saturate-*` | Adjust backdrop saturation filter values.           | [backdrop saturate](/docs/properties/filter/backdrop/saturate) |
+| `backdrop-sepia-*`    | Apply backdrop sepia tone filter effect.            | [backdrop sepia](/docs/properties/filter/backdrop/sepia)       |
+| `backdrop-shadow-*`   | Add backdrop shadow (`drop-shadow`) filter effects. | [backdrop shadow](/docs/properties/filter/backdrop/shadow)     |
+
+</section>

--- a/apps/docs/src/content/docs/properties/filter/invert.mdx
+++ b/apps/docs/src/content/docs/properties/filter/invert.mdx
@@ -1,12 +1,16 @@
 ---
 title: "Invert Filter | @filter"
 description: "Invert colors of element with filter."
-keywords: ["filter", "invert", "color", "effect", "css"]
+keywords: ["filter", "invert", "color", "effect"]
 ---
 
-# invert
+# Invert Filter
 
-invert filter
+Invert colors of element with filter.
+
+Usage:
+
+- `@filter invert-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/filter/meta.json
+++ b/apps/docs/src/content/docs/properties/filter/meta.json
@@ -5,62 +5,19 @@
 	"title": "filter intent",
 	"items": [
 		"blur",
-
-		{
-			"name": "bright",
-			"label": "brightness"
-		},
-
+		"bright",
 		"contrast",
-
-		{
-			"name": "gray",
-			"label": "grayscale"
-		},
-		{
-			"name": "hue",
-			"label": "hue rotate"
-		},
-
+		"gray",
+		"hue",
 		"invert",
 		"opacity",
-
-		{
-			"name": "saturate",
-			"label": "saturation"
-		},
-
+		"saturate",
 		"sepia",
 		"shadow",
 		"preset",
-		"backdrop",
-		"backdrop-blur",
-
 		{
-			"name": "backdrop-bright",
-			"label": "backdrop brightness"
-		},
-
-		"backdrop-contrast",
-
-		{
-			"name": "backdrop-gray",
-			"label": "backdrop grayscale"
-		},
-		{
-			"name": "backdrop-hue",
-			"label": "backdrop hue rotate"
-		},
-
-		"backdrop-invert",
-		"backdrop-opacity",
-
-		{
-			"name": "backdrop-saturate",
-			"label": "backdrop saturation"
-		},
-
-		"backdrop-sepia",
-		"backdrop-shadow"
+			"type": "folder",
+			"name": "backdrop"
+		}
 	]
 }

--- a/apps/docs/src/content/docs/properties/filter/opacity.mdx
+++ b/apps/docs/src/content/docs/properties/filter/opacity.mdx
@@ -1,12 +1,16 @@
 ---
 title: "Opacity Filter | @filter"
 description: "Control element opacity filter effect."
-keywords: ["filter", "opacity", "transparency", "effect", "css"]
+keywords: ["filter", "opacity", "transparency", "effect"]
 ---
 
-# opacity
+# Opacity Filter
 
-opacity filter
+Control element opacity filter effect.
+
+Usage:
+
+- `@filter opacity-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/filter/preset.mdx
+++ b/apps/docs/src/content/docs/properties/filter/preset.mdx
@@ -1,10 +1,16 @@
 ---
 title: "Filter Presets | @filter"
+description: "Use preset, filter combinations for common effects."
+keywords: ["filter", "preset", "templates", "effect", "visual"]
 ---
 
-# preset
+# Filter Presets
 
-`filter` property
+Use preset, filter combinations for common effects.
+
+Usage:
+
+- `@filter preset-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/filter/saturate.mdx
+++ b/apps/docs/src/content/docs/properties/filter/saturate.mdx
@@ -1,12 +1,16 @@
 ---
-title: "Saturate Filter | @filter"
+title: "Saturation Filter | @filter"
 description: "Adjust saturation filter on element colors."
-keywords: ["filter", "saturate", "color", "effect", "css"]
+keywords: ["filter", "saturate", "color", "effect"]
 ---
 
-# saturate
+# Saturation Filter
 
-saturatation filter
+Adjust saturation filter on element colors.
+
+Usage:
+
+- `@filter saturate-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/filter/sepia.mdx
+++ b/apps/docs/src/content/docs/properties/filter/sepia.mdx
@@ -1,12 +1,16 @@
 ---
 title: "Sepia Filter | @filter"
 description: "Apply sepia tone filter effect to elements."
-keywords: ["filter", "sepia", "tone", "effect", "css"]
+keywords: ["filter", "sepia", "tone", "effect"]
 ---
 
-# sepia
+# Sepia Filter
 
-sepia filter
+Apply sepia tone filter effect to elements.
+
+Usage:
+
+- `@filter sepia-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/filter/shadow.mdx
+++ b/apps/docs/src/content/docs/properties/filter/shadow.mdx
@@ -1,12 +1,18 @@
 ---
-title: "Shadow Filter | @filter"
-description: "Add shadow filter effects to elements."
-keywords: ["filter", "shadow", "depth", "effect", "css"]
+title: "Drop Shadow Filter | @filter"
+description: "Add shadow (drop-shadow) filter effects to elements."
+keywords: ["filter", "shadow", "depth", "effect"]
 ---
 
-# shadow
+# Drop Shadow Filter
 
-`filter` property
+Add shadow (`drop-shadow`) filter effects to elements.
+
+Usage:
+
+- `@filter shadow;`
+- `@filter shadow-*;`
+- `@filter shadow-color-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/flex/base.mdx
+++ b/apps/docs/src/content/docs/properties/flex/base.mdx
@@ -1,12 +1,16 @@
 ---
-title: "Flex Basis | @flex"
-description: "Set flex-basis sizing for flex items."
-keywords: ["flex", "basis", "sizing", "layout", "css"]
+title: "Flex Base (Basis) | @flex"
+description: "Set base (flex-basis) sizing for flex items."
+keywords: ["flex", "basis", "sizing", "layout"]
 ---
 
-# base
+# Flex Base (Basis) Size
 
-flex item's base size
+Set base (`flex-basis`) sizing for flex items.
+
+Usage:
+
+- `@flex base-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/flex/content.mdx
+++ b/apps/docs/src/content/docs/properties/flex/content.mdx
@@ -1,12 +1,16 @@
 ---
 title: "Flex Content Alignment | @flex"
-description: "Control flex container content alignment."
-keywords: ["flex", "align", "content", "layout", "css"]
+description: "Control flex container content alignment along cross-axis."
+keywords: ["flex", "align", "content", "layout"]
 ---
 
-# base
+# Align Flex Content
 
-align flex items on multiple lines (cross axis)
+Control flex container content alignment along cross-axis.
+
+Usage:
+
+- `@flex content-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/flex/flow.mdx
+++ b/apps/docs/src/content/docs/properties/flex/flow.mdx
@@ -1,12 +1,20 @@
 ---
-title: "Flex Direction | @flex"
-description: "Define flex layout direction and wrapping."
-keywords: ["flex", "direction", "flow", "layout", "css"]
+title: "Flex Flow OR Direction | @flex"
+description: "Define flex layout flow or direction."
+keywords: ["flex", "direction", "flow", "layout"]
 ---
 
-# flow
+# Flex Flow OR Direction
 
-flex items flow direction
+Define flex layout flow or direction.
+
+Usage:
+
+- `@flex flow-*;`
+- `@flex flow-row;`
+- `@flex flow-row-reverse;`
+- `@flex flow-col;`
+- `@flex flow-col-reverse;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/flex/grow.mdx
+++ b/apps/docs/src/content/docs/properties/flex/grow.mdx
@@ -1,12 +1,18 @@
 ---
-title: "Flex Grow | @flex"
+title: "Grow Flex Item | @flex"
 description: "Set flex grow factor for expanding items."
-keywords: ["flex", "grow", "expand", "layout", "css"]
+keywords: ["flex", "grow", "expand", "layout"]
 ---
 
-# grow
+# Grow Flex Item
 
-flex item's grow factor
+Set flex grow factor for expanding items.
+
+Usage:
+
+- `@flex grow;`
+- `@flex grow-0;`
+- `@flex grow-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/flex/index.mdx
+++ b/apps/docs/src/content/docs/properties/flex/index.mdx
@@ -13,17 +13,17 @@ Flex intent contains `flex` layout related utilities.
 
 Utilities available in `@flex` intent are listed below.
 
-| Utility     | Description                                     | Documentation                            |
-| ----------- | ----------------------------------------------- | ---------------------------------------- |
-| `base-*`    | flex item's base size                           | [base](/docs/properties/flex/base)       |
-| `content-*` | align flex items on multiple lines (cross axis) | [base](/docs/properties/flex/content)    |
-| `flow-*`    | flex items flow direction                       | [flow](/docs/properties/flex/flow)       |
-| `grow-*`    | flex item's grow factor                         | [grow](/docs/properties/flex/grow)       |
-| `items-*`   | align flex items (cross axis)                   | [items](/docs/properties/flex/items)     |
-| `justify-*` | align flex items (main axis)                    | [justify](/docs/properties/flex/justify) |
-| `order-*`   | order of flex item's                            | [order](/docs/properties/flex/order)     |
-| `place-*`   | align flex items (main & cross axis)            | [place](/docs/properties/flex/place)     |
-| `preset-*`  | `flex` property                                 | [preset](/docs/properties/flex/preset)   |
-| `self-*`    | align flex item itself (cross axis)             | [self](/docs/properties/flex/self)       |
-| `shrink-*`  | flex item's shrink factor                       | [shrink](/docs/properties/flex/shrink)   |
-| `wrap-*`    | adjust flex items on multiple lines             | [wrap](/docs/properties/flex/wrap)       |
+| Utility     | Description                                                       | Documentation                            |
+| ----------- | ----------------------------------------------------------------- | ---------------------------------------- |
+| `base-*`    | Set base (`flex-basis`) sizing for flex items.                    | [base](/docs/properties/flex/base)       |
+| `content-*` | Control flex container content alignment along cross-axis.        | [content](/docs/properties/flex/content) |
+| `flow-*`    | Define flex layout flow or direction.                             | [flow](/docs/properties/flex/flow)       |
+| `grow-*`    | Set flex grow factor for expanding items.                         | [grow](/docs/properties/flex/grow)       |
+| `items-*`   | Align flex items within container along cross-axis.               | [items](/docs/properties/flex/items)     |
+| `justify-*` | Justify flex content distribution along main-axis.                | [justify](/docs/properties/flex/justify) |
+| `order-*`   | Set flex item order within container.                             | [order](/docs/properties/flex/order)     |
+| `place-*`   | Set flex items alignment along main-axis and cross-axis combined. | [place](/docs/properties/flex/place)     |
+| `preset-*`  | Use preset, flexbox sizing combinations.                          | [preset](/docs/properties/flex/preset)   |
+| `self-*`    | Align individual flex item within container along cross-axis.     | [self](/docs/properties/flex/self)       |
+| `shrink-*`  | Control flex shrink factor for items.                             | [shrink](/docs/properties/flex/shrink)   |
+| `wrap-*`    | Control flex wrapping behavior.                                   | [wrap](/docs/properties/flex/wrap)       |

--- a/apps/docs/src/content/docs/properties/flex/items.mdx
+++ b/apps/docs/src/content/docs/properties/flex/items.mdx
@@ -1,12 +1,16 @@
 ---
 title: "Flex Items Alignment | @flex"
-description: "Align flex items within container."
-keywords: ["flex", "align", "items", "layout", "css"]
+description: "Align flex items within container along cross-axis."
+keywords: ["flex", "align", "items", "layout"]
 ---
 
-# items
+# Align Flex Items
 
-align flex items (cross axis)
+Align flex items within container along cross-axis.
+
+Usage:
+
+- `@flex items-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/flex/justify.mdx
+++ b/apps/docs/src/content/docs/properties/flex/justify.mdx
@@ -1,12 +1,16 @@
 ---
 title: "Flex Justify Content | @flex"
-description: "Justify flex content distribution along main axis."
-keywords: ["flex", "justify", "align", "layout", "css"]
+description: "Justify flex content distribution along main-axis."
+keywords: ["flex", "justify", "align", "layout"]
 ---
 
-# justify
+# Justify Flex Content
 
-align flex items (main axis)
+Justify flex content distribution along main-axis.
+
+Usage:
+
+- `@flex justify-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/flex/order.mdx
+++ b/apps/docs/src/content/docs/properties/flex/order.mdx
@@ -1,12 +1,16 @@
 ---
-title: "Flex Order | @flex"
+title: "Flex Item Order | @flex"
 description: "Set flex item order within container."
-keywords: ["flex", "order", "sequence", "layout", "css"]
+keywords: ["flex", "order", "sequence", "layout"]
 ---
 
-# order
+# Flex Item Order
 
-order of flex item's
+Set flex item order within container.
+
+Usage:
+
+- `@flex order-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/flex/place.mdx
+++ b/apps/docs/src/content/docs/properties/flex/place.mdx
@@ -1,12 +1,16 @@
 ---
-title: "Flex Place Alignment | @flex"
-description: "Place flex items with combined alignment."
-keywords: ["flex", "place", "align", "layout", "css"]
+title: "Place Flex Items | @flex"
+description: "Set flex items alignment along main-axis and cross-axis combined."
+keywords: ["flex", "place", "align", "layout"]
 ---
 
-# place
+# Place Flex Items
 
-align flex items (main & cross axis)
+Set flex items alignment along main-axis and cross-axis combined.
+
+Usage:
+
+- `@flex place-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/flex/preset.mdx
+++ b/apps/docs/src/content/docs/properties/flex/preset.mdx
@@ -1,12 +1,16 @@
 ---
 title: "Flex Presets | @flex"
-description: "Use preset flexbox layout combinations."
-keywords: ["flex", "preset", "template", "layout", "css"]
+description: "Use preset, flexbox sizing combinations."
+keywords: ["flex", "preset", "template", "sizing"]
 ---
 
-# preset
+# Flex Presets
 
-`flex` property
+Use preset, flexbox sizing combinations.
+
+Usage:
+
+- `@flex preset-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/flex/self.mdx
+++ b/apps/docs/src/content/docs/properties/flex/self.mdx
@@ -1,12 +1,16 @@
 ---
-title: "Flex Self Alignment | @flex"
-description: "Align individual flex item within container."
-keywords: ["flex", "self", "align", "item", "css"]
+title: "Align Self | @flex"
+description: "Align individual flex item within container along cross-axis."
+keywords: ["flex", "self", "align", "item"]
 ---
 
-# self
+# Align Self
 
-align flex item itself (cross axis)
+Align individual flex item within container along cross-axis.
+
+Usage:
+
+- `@flex self-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/flex/shrink.mdx
+++ b/apps/docs/src/content/docs/properties/flex/shrink.mdx
@@ -1,12 +1,16 @@
 ---
-title: "Flex Shrink | @flex"
+title: "Shrink Flex Item | @flex"
 description: "Control flex shrink factor for items."
-keywords: ["flex", "shrink", "compress", "layout", "css"]
+keywords: ["flex", "shrink", "compress", "layout"]
 ---
 
-# shrink
+# Shrink Flex Item
 
-flex item's shrink factor
+Control flex shrink factor for items.
+
+Usage:
+
+- `@flex shrink-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/flex/wrap.mdx
+++ b/apps/docs/src/content/docs/properties/flex/wrap.mdx
@@ -1,12 +1,19 @@
 ---
-title: "Flex Wrap | @flex"
+title: "Wrap Flex Items | @flex"
 description: "Control flex wrapping behavior."
-keywords: ["flex", "wrap", "flow", "layout", "css"]
+keywords: ["flex", "wrap", "flow", "layout"]
 ---
 
-# wrap
+# Wrap Flex Items
 
-adjust flex items on multiple lines
+Control flex wrapping behavior.
+
+Usage:
+
+- `@flex wrap;`
+- `@flex wrap-reverse;`
+- `@flex wrap-none;`
+- `@flex wrap-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/form/accent.mdx
+++ b/apps/docs/src/content/docs/properties/form/accent.mdx
@@ -1,12 +1,16 @@
 ---
-title: "Accent Color | @form"
+title: "Form Controls Accent Color | @form"
 description: "Set form control accent color."
-keywords: ["form", "accent", "color", "input", "css"]
+keywords: ["form", "accent", "color", "input"]
 ---
 
-# accent color
+# From Controls Accent Color
 
-color for form controls
+Set form control accent color.
+
+Usage:
+
+- `@form accent-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/form/index.mdx
+++ b/apps/docs/src/content/docs/properties/form/index.mdx
@@ -1,8 +1,8 @@
 ---
 title: "Form Intent - Form Control Styling"
 description:
-  "Form control styling with @form intent. Input appearance, accent colors, and
-  form element styling."
+  "Form control styling with @form intent. appearance, accent colors, and other
+  styling."
 keywords:
   ["@form", "form controls", "input", "form styling", "checkbox", "radio"]
 ---
@@ -13,8 +13,8 @@ Form intent contains **form controls** related utilities.
 
 Utilities available in `@form` intent are listed below.
 
-| Utility    | Description                            | Documentation                                |
-| ---------- | -------------------------------------- | -------------------------------------------- |
-| `accent-*` | color for form controls                | [accent color](/docs/properties/form/accent) |
-| `resize-*` | resize `text-area` input size          | [resize](/docs/properties/form/resize)       |
-| `skin-*`   | override native style of form controls | [skin](/docs/properties/form/skin)           |
+| Utility    | Description                                          | Documentation                          |
+| ---------- | ---------------------------------------------------- | -------------------------------------- |
+| `accent-*` | Set form control accent color.                       | [accent](/docs/properties/form/accent) |
+| `resize-*` | Control textarea resize behavior.                    | [resize](/docs/properties/form/resize) |
+| `skin-*`   | Override native styles (appearance) of form control. | [skin](/docs/properties/form/skin)     |

--- a/apps/docs/src/content/docs/properties/form/meta.json
+++ b/apps/docs/src/content/docs/properties/form/meta.json
@@ -3,12 +3,5 @@
 	"name": "index",
 	"label": "@form",
 	"title": "form intent",
-	"items": [
-		{
-			"name": "accent",
-			"label": "accent color"
-		},
-		"resize",
-		"skin"
-	]
+	"items": ["accent", "resize", "skin"]
 }

--- a/apps/docs/src/content/docs/properties/form/resize.mdx
+++ b/apps/docs/src/content/docs/properties/form/resize.mdx
@@ -1,12 +1,16 @@
 ---
-title: "Resize Behavior | @form"
-description: "Control textarea and element resize behavior."
-keywords: ["form", "resize", "textarea", "control", "css"]
+title: "Resize Text Area | @form"
+description: "Control textarea resize behavior."
+keywords: ["form", "resize", "textarea", "control"]
 ---
 
-# resize
+# Resize Text Area
 
-resize `text-area` input size
+Control textarea resize behavior.
+
+Usage:
+
+- `@form resize-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/form/skin.mdx
+++ b/apps/docs/src/content/docs/properties/form/skin.mdx
@@ -1,12 +1,16 @@
 ---
-title: "Form Appearance | @form"
-description: "Apply form control appearance and styling."
-keywords: ["form", "skin", "style", "control", "css"]
+title: "Form Control Appearance | @form"
+description: "Override native styles (appearance) of form control."
+keywords: ["form", "skin", "style", "control"]
 ---
 
-# skin
+# Form Control Appearance
 
-override native style of form controls
+Override native styles (appearance) of form control.
+
+Usage:
+
+- `@form skin-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/grid/col.mdx
+++ b/apps/docs/src/content/docs/properties/grid/col.mdx
@@ -1,12 +1,19 @@
 ---
-title: "Grid Column Span | @grid"
-description: "Set grid item column span position."
-keywords: ["grid", "column", "col", "layout", "css"]
+title: "Grid Columns | @grid"
+description: "Set grid item's size and location on columns."
+keywords: ["grid", "column", "col", "layout"]
 ---
 
-# col
+# Grid Columns
 
-grid item's size and location on columns
+Set grid item's size and location on columns.
+
+Usage:
+
+- `@grid col-start-*;`
+- `@grid col-end-*;`
+- `@grid col-size-*;`
+- `@grid col-span-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/grid/cols.mdx
+++ b/apps/docs/src/content/docs/properties/grid/cols.mdx
@@ -1,12 +1,16 @@
 ---
-title: "Grid Columns Layout | @grid"
-description: "Define grid columns layout structure."
-keywords: ["grid", "columns", "layout", "grid-template", "css"]
+title: "Grid Columns Count | @grid"
+description: "Define number of grid columns."
+keywords: ["grid", "columns", "layout", "grid-template"]
 ---
 
-# cols
+# Grid Columns Count
 
-number of grid columns
+Define number of grid columns.
+
+Usage:
+
+- `@grid cols-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/grid/content.mdx
+++ b/apps/docs/src/content/docs/properties/grid/content.mdx
@@ -1,12 +1,16 @@
 ---
 title: "Grid Content Alignment | @grid"
-description: "Control grid content alignment."
-keywords: ["grid", "align", "content", "layout", "css"]
+description: "Control grid content alignment along block-axis."
+keywords: ["grid", "align", "content", "layout"]
 ---
 
-# content
+# Align Grid Content
 
-align grid items (block axis)
+Control grid content alignment along block-axis.
+
+Usage:
+
+- `@grid content-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/grid/flow.mdx
+++ b/apps/docs/src/content/docs/properties/grid/flow.mdx
@@ -1,12 +1,20 @@
 ---
 title: "Grid Flow | @grid"
-description: "Define grid layout flow direction."
-keywords: ["grid", "flow", "direction", "layout", "css"]
+description: "Define grid layout flow direction using auto-placement algorithm."
+keywords: ["grid", "flow", "direction", "layout"]
 ---
 
-# flow
+# Grid Flow Direction
 
-grid item's auto-placement algorithm
+Define grid layout flow direction using auto-placement algorithm.
+
+Usage:
+
+- `@grid flow-*;`
+- `@grid flow-row;`
+- `@grid flow-row-dense;`
+- `@grid flow-col;`
+- `@grid flow-col-dense;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/grid/index.mdx
+++ b/apps/docs/src/content/docs/properties/grid/index.mdx
@@ -20,17 +20,17 @@ Grid intent contains `grid` layout related utilities.
 
 Utilities available in `@grid` intent are listed below.
 
-| Utility     | Description                              | Documentation                            |
-| ----------- | ---------------------------------------- | ---------------------------------------- |
-| `col-*`     | grid item's size and location on columns | [col](/docs/properties/grid/col)         |
-| `cols-*`    | number of grid columns                   | [cols](/docs/properties/grid/cols)       |
-| `content-*` | align grid items (block axis)            | [content](/docs/properties/grid/content) |
-| `flow-*`    | grid item's auto-placement algorithm     | [flow](/docs/properties/grid/flow)       |
-| `items-*`   | align grid items (block axis)            | [items](/docs/properties/grid/items)     |
-| `justify-*` | align grid items (inline axis)           | [justify](/docs/properties/grid/justify) |
-| `order-*`   | order of grid item's                     | [order](/docs/properties/grid/order)     |
-| `place-*`   | align grid items (block & inline axis)   | [place](/docs/properties/grid/place)     |
-| `preset-*`  | `grid` property                          | [preset](/docs/properties/grid/preset)   |
-| `row-*`     | grid item's size and location on rows    | [row](/docs/properties/grid/row)         |
-| `rows-*`    | number of grid rows                      | [rows](/docs/properties/grid/rows)       |
-| `self-*`    | align grid item itself (block axis)      | [self](/docs/properties/grid/self)       |
+| Utility     | Description                                                         | Documentation                            |
+| ----------- | ------------------------------------------------------------------- | ---------------------------------------- |
+| `col-*`     | Set grid item's size and location on columns.                       | [col](/docs/properties/grid/col)         |
+| `cols-*`    | Define number of grid columns.                                      | [cols](/docs/properties/grid/cols)       |
+| `content-*` | Control grid content alignment along block-axis.                    | [content](/docs/properties/grid/content) |
+| `flow-*`    | Define grid layout flow direction using auto-placement algorithm.   | [flow](/docs/properties/grid/flow)       |
+| `items-*`   | Align grid items within container along block-axis.                 | [items](/docs/properties/grid/items)     |
+| `justify-*` | Align grid items along inline-axis.                                 | [justify](/docs/properties/grid/justify) |
+| `order-*`   | Set grid item's order or position.                                  | [order](/docs/properties/grid/order)     |
+| `place-*`   | Set grid items alignment along block-axis and inline-axis combined. | [place](/docs/properties/grid/place)     |
+| `preset-*`  | Use preset, grid layout combinations.                               | [preset](/docs/properties/grid/preset)   |
+| `row-*`     | Set grid item's size and location on rows.                          | [row](/docs/properties/grid/row)         |
+| `rows-*`    | Define number of grid rows.                                         | [rows](/docs/properties/grid/rows)       |
+| `self-*`    | Align individual grid item along block-axis.                        | [self](/docs/properties/grid/self)       |

--- a/apps/docs/src/content/docs/properties/grid/items.mdx
+++ b/apps/docs/src/content/docs/properties/grid/items.mdx
@@ -1,12 +1,16 @@
 ---
 title: "Grid Items Alignment | @grid"
-description: "Align grid items within container."
-keywords: ["grid", "align", "items", "layout", "css"]
+description: "Align grid items within container along block-axis."
+keywords: ["grid", "align", "items", "layout"]
 ---
 
-# items
+# Align Grid Items
 
-align grid items (block axis)
+Align grid items within container along block-axis.
+
+Usage:
+
+- `@grid items-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/grid/justify.mdx
+++ b/apps/docs/src/content/docs/properties/grid/justify.mdx
@@ -1,12 +1,18 @@
 ---
 title: "Grid Justify Content | @grid"
-description: "Justify grid content along main axis."
-keywords: ["grid", "justify", "align", "layout", "css"]
+description: "Align grid items along inline-axis."
+keywords: ["grid", "justify", "align", "layout"]
 ---
 
-# justify
+# Justify Grid Content
 
-align grid items (inline axis)
+Align grid items along inline-axis.
+
+Usage:
+
+- `@grid justify-*;`
+- `@grid justify-items-*;`
+- `@grid justify-self-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/grid/order.mdx
+++ b/apps/docs/src/content/docs/properties/grid/order.mdx
@@ -1,12 +1,16 @@
 ---
 title: "Grid Order | @grid"
-description: "Set grid item order position."
-keywords: ["grid", "order", "sequence", "layout", "css"]
+description: "Set grid item's order or position."
+keywords: ["grid", "order", "sequence", "layout"]
 ---
 
-# order
+# Grid Item Order
 
-order of grid item's
+Set grid item's order or position.
+
+Usage:
+
+- `@grid order-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/grid/place.mdx
+++ b/apps/docs/src/content/docs/properties/grid/place.mdx
@@ -1,12 +1,19 @@
 ---
-title: "Grid Place Alignment | @grid"
-description: "Place grid items with combined alignment."
-keywords: ["grid", "place", "align", "layout", "css"]
+title: "Place Grid Items | @grid"
+description:
+  "Set grid items alignment along block-axis and inline-axis combined."
+keywords: ["grid", "place", "align", "layout"]
 ---
 
-# place
+# Place Grid Items
 
-align grid items (block & inline axis)
+Set grid items alignment along block-axis and inline-axis combined.
+
+Usage:
+
+- `@grid place-*;`
+- `@grid place-items-*;`
+- `@grid place-self-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/grid/preset.mdx
+++ b/apps/docs/src/content/docs/properties/grid/preset.mdx
@@ -1,12 +1,16 @@
 ---
 title: "Grid Presets | @grid"
-description: "Use preset grid layout combinations."
-keywords: ["grid", "preset", "template", "layout", "css"]
+description: "Use preset, grid layout combinations."
+keywords: ["grid", "preset", "template", "layout"]
 ---
 
-# preset
+# Grid Presets
 
-`grid` property
+Use preset, grid layout combinations.
+
+Usage:
+
+- `@grid preset-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/grid/row.mdx
+++ b/apps/docs/src/content/docs/properties/grid/row.mdx
@@ -1,12 +1,19 @@
 ---
-title: "Grid Row Span | @grid"
-description: "Set grid item row span position."
-keywords: ["grid", "row", "span", "layout", "css"]
+title: "Grid Rows | @grid"
+description: "Set grid item's size and location on rows."
+keywords: ["grid", "row", "span", "layout"]
 ---
 
-# row
+# Grid Rows
 
-grid item's size and location on rows
+Set grid item's size and location on rows.
+
+Usage:
+
+- `@grid row-start-*;`
+- `@grid row-end-*;`
+- `@grid row-size-*;`
+- `@grid row-span-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/grid/rows.mdx
+++ b/apps/docs/src/content/docs/properties/grid/rows.mdx
@@ -1,12 +1,16 @@
 ---
-title: "Grid Rows Layout | @grid"
-description: "Define grid rows layout structure."
-keywords: ["grid", "rows", "layout", "grid-template", "css"]
+title: "Grid Rows Count | @grid"
+description: "Define number of grid rows."
+keywords: ["grid", "rows", "layout", "grid-template"]
 ---
 
-# rows
+# Grid Rows Count
 
-number of grid rows
+Define number of grid rows.
+
+Usage:
+
+- `@grid rows-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/grid/self.mdx
+++ b/apps/docs/src/content/docs/properties/grid/self.mdx
@@ -1,12 +1,16 @@
 ---
-title: "Grid Self Alignment | @grid"
-description: "Align individual grid item."
-keywords: ["grid", "self", "align", "item", "css"]
+title: "Align Self | @grid"
+description: "Align individual grid item along block-axis."
+keywords: ["grid", "self", "align", "item"]
 ---
 
-# self
+# Align Self
 
-align grid item itself (block axis)
+Align individual grid item along block-axis.
+
+Usage:
+
+- `@grid self-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/index.mdx
+++ b/apps/docs/src/content/docs/properties/index.mdx
@@ -2,9 +2,8 @@
 title: "Properties and Intent Categories"
 description:
   "Overview of all Shilp CSS properties grouped into intents. Complete guide to
-  19 style intent categories."
-keywords:
-  ["properties", "intents", "styling categories", "CSS utilities overview"]
+  intent categories."
+keywords: ["properties", "intents", "styling categories", "overview"]
 ---
 
 # Properties Overview
@@ -34,26 +33,26 @@ This section lists all built-in intents shipped with Shilp CSS.
 Intent are derived from properties. Shilp CSS simply **organizes properties
 under intents**.
 
-| Intent      | Description                                                        | Documentation                          |
-| ----------- | ------------------------------------------------------------------ | -------------------------------------- |
-| `@adjust`   | element's `transform` related utilities                            | [@adjust](/docs/properties/adjust)     |
-| `@animate`  | element's `animation` related utilities                            | [@animate](/docs/properties/animate)   |
-| `@bg`       | element's `background` related utilities                           | [@bg](/docs/properties/bg)             |
-| `@border`   | element's `border` related utilities                               | [@border](/docs/properties/border)     |
-| `@filter`   | element's `filter` (including `backdrop-filter`) related utilities | [@filter](/docs/properties/filter)     |
-| `@flex`     | element's `flex` layout related utilities                          | [@flex](/docs/properties/flex)         |
-| `@form`     | element's **form controls** related utilities                      | [@form](/docs/properties/form)         |
-| `@grid`     | element's `grid` layout related utilities                          | [@grid](/docs/properties/grid)         |
-| `@layout`   | **element's layout** related utilities                             | [@layout](/docs/properties/layout)     |
-| `@list`     | **list** items related utilities                                   | [@list](/docs/properties/list)         |
-| `@live`     | **user interaction** related utilities                             | [@live](/docs/properties/live)         |
-| `@mask`     | **element's masking** related utilities                            | [@mask](/docs/properties/mask)         |
-| `@phase`    | element's `transition` related utilities                           | [@phase](/docs/properties/phase)       |
-| `@position` | **element's position** related utilities                           | [@position](/docs/properties/position) |
-| `@size`     | **element's dimensions** related utilities                         | [@size](/docs/properties/size)         |
-| `@space`    | **element's spacing** related utilities                            | [@space](/docs/properties/space)       |
-| `@svg`      | `svg` related utilities                                            | [@svg](/docs/properties/svg)           |
-| `@table`    | `table` layout related utilities                                   | [@table](/docs/properties/table)       |
-| `@text`     | **element's typography** related utilities                         | [@text](/docs/properties/text)         |
+| Intent      | Description                                                              | Documentation                          |
+| ----------- | ------------------------------------------------------------------------ | -------------------------------------- |
+| `@adjust`   | Control rotation, scaling, skewing, positioning and more.                | [@adjust](/docs/properties/adjust)     |
+| `@animate`  | Control animation properties, delays, durations, and more.               | [@animate](/docs/properties/animate)   |
+| `@bg`       | Control background color, gradients, background images, and more.        | [@bg](/docs/properties/bg)             |
+| `@border`   | Control border color, thickness (width), radius, and style properties.   | [@border](/docs/properties/border)     |
+| `@filter`   | Blur, brightness, grayscale, backdrop filters and more.                  | [@filter](/docs/properties/filter)     |
+| `@flex`     | Alignment, direction, growth, and other flex layout utilities.           | [@flex](/docs/properties/flex)         |
+| `@form`     | form control elementst appearance, accent colors, and more.              | [@form](/docs/properties/form)         |
+| `@grid`     | Grid layout, columns, rows, span, order and more.                        | [@grid](/docs/properties/grid)         |
+| `@layout`   | Display, shadows, overflow, and more.                                    | [@layout](/docs/properties/layout)     |
+| `@list`     | List markers alignment and styles.                                       | [@list](/docs/properties/list)         |
+| `@live`     | Cursor, user-select, outlien and other user interactions.                | [@live](/docs/properties/live)         |
+| `@mask`     | Masking element with clipping, gradients, image and more.                | [@mask](/docs/properties/mask)         |
+| `@phase`    | Control transitions, timing, speed, and more.                            | [@phase](/docs/properties/phase)       |
+| `@position` | Controls positioned element's method (or type) and offset (or distance). | [@position](/docs/properties/position) |
+| `@size`     | Controls width and height (dimensions).                                  | [@size](/docs/properties/size)         |
+| `@space`    | Controls margin, padding and gap.                                        | [@space](/docs/properties/space)       |
+| `@svg`      | Control SVG's stroke and fill properties.                                | [@svg](/docs/properties/svg)           |
+| `@table`    | Table's caption position, cells border effect and spacing.               | [@table](/docs/properties/table)       |
+| `@text`     | Font size, weight, color, alignment, and more.                           | [@text](/docs/properties/text)         |
 
 </section>

--- a/apps/docs/src/content/docs/properties/layout/blend.mdx
+++ b/apps/docs/src/content/docs/properties/layout/blend.mdx
@@ -1,12 +1,16 @@
 ---
 title: "Mix Blend Mode | @layout"
-description: "Set mix-blend-mode for element compositing."
-keywords: ["layout", "blend", "mix", "compositing", "css"]
+description: "Set mix-blend-mode for layering effects."
+keywords: ["layout", "blend", "mix", "compositing"]
 ---
 
-# blend
+# Mix Blend Mode
 
-element's blends with the background
+Set `mix-blend-mode` for layering effects.
+
+Usage:
+
+- `@layout blend-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/layout/box.mdx
+++ b/apps/docs/src/content/docs/properties/layout/box.mdx
@@ -1,12 +1,18 @@
 ---
 title: "Box Sizing | @layout"
 description: "Control box-sizing model for elements."
-keywords: ["layout", "box", "sizing", "model", "css"]
+keywords: ["layout", "box", "sizing", "model"]
 ---
 
-# box
+# Box Sizing
 
-controls padding and border in element's size
+Control box-sizing model for elements.
+
+Usage:
+
+- `@layout box-*;`
+- `@layout box-border;`
+- `@layout box-content;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/layout/float.mdx
+++ b/apps/docs/src/content/docs/properties/layout/float.mdx
@@ -1,12 +1,17 @@
 ---
-title: "Float Positioning | @layout"
-description: "Set float positioning for elements."
-keywords: ["layout", "float", "positioning", "flow", "css"]
+title: "Float Items | @layout"
+description: "Positions element (float) and letting content wrap around."
+keywords: ["layout", "float", "positioning", "flow"]
 ---
 
-# float
+# Float Items
 
-positions element and letting content wrap around
+Positions element (float) and letting content wrap around.
+
+Usage:
+
+- `@layout float-*;`
+- `@layout float-clear-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/layout/hide.mdx
+++ b/apps/docs/src/content/docs/properties/layout/hide.mdx
@@ -1,12 +1,17 @@
 ---
 title: "Hide Elements | @layout"
-description: "Hide elements from view and layout."
-keywords: ["layout", "hide", "display", "visibility", "css"]
+description: "Hide elements from view without layout layout."
+keywords: ["layout", "hide", "display", "visibility"]
 ---
 
-# hide
+# Hide Elements
 
-hides an element without affecting layout
+Hide elements from view without layout layout.
+
+Usage:
+
+- `@layout hide;`
+- `@layout hide-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/layout/index.mdx
+++ b/apps/docs/src/content/docs/properties/layout/index.mdx
@@ -1,8 +1,8 @@
 ---
 title: "Layout Intent - Display and Layout"
 description:
-  "Layout styling with @layout intent. Display modes, shadows, overflow, and
-  layout utilities."
+  "Layout styling with @layout intent. Display, shadows, overflow, and layout
+  utilities."
 keywords: ["@layout", "display", "layout", "shadow", "overflow", "visibility"]
 ---
 
@@ -12,19 +12,19 @@ Layout intent contains **element's layout** related utilities.
 
 Utilities available in `@layout` intent are listed below.
 
-| Utility      | Description                                       | Documentation                                |
-| ------------ | ------------------------------------------------- | -------------------------------------------- |
-| `blend-*`    | element's blends with the background              | [blend](/docs/properties/layout/blend)       |
-| `box-*`      | controls padding and border in element's size     | [box](/docs/properties/layout/box)           |
-| `float-*`    | positions element and letting content wrap around | [float](/docs/properties/layout/float)       |
-| `hide`       | hides an element without affecting layout         | [hide](/docs/properties/layout/hide)         |
-| `is-*`       | specifies how an element is rendered in layout    | [is](/docs/properties/layout/is)             |
-| `isolate-*`  | creates a new stacking context for an element     | [isolate](/docs/properties/layout/isolate)   |
-| `layer-*`    | element’s stack order on the z-axis               | [layer](/docs/properties/layout/layer)       |
-| `object-*`   | fits and positions content in container           | [object](/docs/properties/layout/object)     |
-| `opacity-*`  | element's transparency level                      | [opacity](/docs/properties/layout/opacity)   |
-| `overflow-*` | handles content overflow                          | [overflow](/docs/properties/layout/overflow) |
-| `ratio-*`    | element's width-to-height ratio                   | [ratio](/docs/properties/layout/ratio)       |
-| `shadow-*`   | adds shadow to an element                         | [shadow](/docs/properties/layout/shadow)     |
-| `show`       | makes the element visible (use with `hide`)       | [show](/docs/properties/layout/show)         |
-| `theme-*`    | suggests light or dark theme for the page         | [theme](/docs/properties/layout/theme)       |
+| Utility      | Description                                                    | Documentation                                |
+| ------------ | -------------------------------------------------------------- | -------------------------------------------- |
+| `blend-*`    | Set `mix-blend-mode` for layering effects.                     | [blend](/docs/properties/layout/blend)       |
+| `box-*`      | Control box-sizing model for elements.                         | [box](/docs/properties/layout/box)           |
+| `float-*`    | Positions element (float) and letting content wrap around.     | [float](/docs/properties/layout/float)       |
+| `hide`       | Hide elements from view without layout layout.                 | [hide](/docs/properties/layout/hide)         |
+| `is-*`       | Define how an element is rendered (displayed) in layout.       | [is](/docs/properties/layout/is)             |
+| `isolate-*`  | Create new stacking context for elements.                      | [isolate](/docs/properties/layout/isolate)   |
+| `layer-*`    | Control z-index stacking order.                                | [layer](/docs/properties/layout/layer)       |
+| `object-*`   | Control graphical elements size and position inside container. | [object](/docs/properties/layout/object)     |
+| `opacity-*`  | Control element opacity and transparency.                      | [opacity](/docs/properties/layout/opacity)   |
+| `overflow-*` | Handle overflowing content.                                    | [overflow](/docs/properties/layout/overflow) |
+| `ratio-*`    | Set aspect ratio (width-to-height) for elements.               | [ratio](/docs/properties/layout/ratio)       |
+| `shadow-*`   | Add shadow (box) effects to elements.                          | [shadow](/docs/properties/layout/shadow)     |
+| `show`       | Show hidden elements in layout (use with `hide`).              | [show](/docs/properties/layout/show)         |
+| `theme-*`    | Apply browser's native dark/light themes to elements.          | [theme](/docs/properties/layout/theme)       |

--- a/apps/docs/src/content/docs/properties/layout/is.mdx
+++ b/apps/docs/src/content/docs/properties/layout/is.mdx
@@ -1,12 +1,16 @@
 ---
 title: "Display Type | @layout"
-description: "Define element display property type."
-keywords: ["layout", "display", "is", "block", "css"]
+description: "Define how an element is rendered (displayed) in layout."
+keywords: ["layout", "display", "is", "block"]
 ---
 
-# is
+# Display Type
 
-specifies how an element is rendered in layout
+Define how an element is rendered (displayed) in layout.
+
+Usage:
+
+- `@layout is-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/layout/isolate.mdx
+++ b/apps/docs/src/content/docs/properties/layout/isolate.mdx
@@ -1,12 +1,18 @@
 ---
 title: "Stacking Context Isolation | @layout"
 description: "Create new stacking context for elements."
-keywords: ["layout", "isolate", "stacking", "context", "css"]
+keywords: ["layout", "isolate", "stacking", "context"]
 ---
 
-# isolate
+# Stacking Context Isolation
 
-creates a new stacking context for an element
+Create new stacking context for elements.
+
+Usage:
+
+- `@layout isolate-*;`
+- `@layout isolate-auto;`
+- `@layout isolate-forced;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/layout/layer.mdx
+++ b/apps/docs/src/content/docs/properties/layout/layer.mdx
@@ -1,12 +1,16 @@
 ---
-title: "Z Index Layer | @layout"
+title: "Elements Layer | @layout"
 description: "Control z-index stacking order."
-keywords: ["layout", "layer", "z-index", "stacking", "css"]
+keywords: ["layout", "layer", "z-index", "stacking"]
 ---
 
-# layer
+# Elements Layer
 
-element’s stack order on the z-axis
+Control z-index stacking order.
+
+Usage:
+
+- `@layout layer-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/layout/object.mdx
+++ b/apps/docs/src/content/docs/properties/layout/object.mdx
@@ -1,12 +1,17 @@
 ---
 title: "Object Fit and Position | @layout"
-description: "Control object-fit and object-position."
-keywords: ["layout", "object", "fit", "position", "css"]
+description: "Control graphical elements size and position inside container."
+keywords: ["layout", "object", "fit", "position"]
 ---
 
-# object
+# Object Fit and Position
 
-fits and positions content in container
+Control graphical elements size and position inside container.
+
+Usage:
+
+- `@layout object-fit-*;`
+- `@layout object-position-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/layout/opacity.mdx
+++ b/apps/docs/src/content/docs/properties/layout/opacity.mdx
@@ -1,12 +1,16 @@
 ---
 title: "Element Opacity | @layout"
 description: "Control element opacity and transparency."
-keywords: ["layout", "opacity", "transparency", "alpha", "css"]
+keywords: ["layout", "opacity", "transparency", "alpha"]
 ---
 
-# opacity
+# Element Opacity
 
-element's transparency level
+Control element opacity and transparency.
+
+Usage:
+
+- `@layout opacity-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/layout/overflow.mdx
+++ b/apps/docs/src/content/docs/properties/layout/overflow.mdx
@@ -1,12 +1,18 @@
 ---
-title: "Overflow Handling | @layout"
-description: "Handle overflow content display."
-keywords: ["layout", "overflow", "hidden", "scroll", "css"]
+title: "Content Overflow | @layout"
+description: "Handle overflowing content."
+keywords: ["layout", "overflow", "hidden", "scroll"]
 ---
 
-# overflow
+# Content Overflow
 
-handles content overflow
+Handle overflowing content.
+
+Usage:
+
+- `@layout overflow-*;`
+- `@layout overflow-x-*;`
+- `@layout overflow-y-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/layout/ratio.mdx
+++ b/apps/docs/src/content/docs/properties/layout/ratio.mdx
@@ -1,12 +1,16 @@
 ---
 title: "Aspect Ratio | @layout"
-description: "Set aspect ratio for elements."
-keywords: ["layout", "ratio", "aspect", "proportion", "css"]
+description: "Set aspect ratio (width-to-height) for elements."
+keywords: ["layout", "ratio", "aspect", "proportion"]
 ---
 
-# ratio
+# Aspect Ratio
 
-element's width-to-height ratio
+Set aspect ratio (width-to-height) for elements.
+
+Usage:
+
+- `@layout ratio-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/layout/shadow.mdx
+++ b/apps/docs/src/content/docs/properties/layout/shadow.mdx
@@ -1,12 +1,20 @@
 ---
-title: "Drop Shadow | @layout"
-description: "Add drop shadow effects to elements."
-keywords: ["layout", "shadow", "depth", "effect", "css"]
+title: "Box Shadow | @layout"
+description: "Add box shadow effects to elements."
+keywords: ["layout", "shadow", "depth", "effect"]
 ---
 
-# shadow
+# Box Shadow
 
-adds shadow to an element
+Add shadow (box) effects to elements.
+
+Usage:
+
+- `@layout shadow;`
+- `@layout shadow-*;`
+- `@layout shadow-inset;`
+- `@layout shadow-inset-*;`
+- `@layout shadow-color-*;`
 
 <Alert variant="info">
 
@@ -33,41 +41,41 @@ const shilpConfig = {
 					special: true,
 					values: {
 						none: `
-					box-shadow: 0 0 #0000<i>;
-					--b-sdw: initial<i>;
-				`,
+							box-shadow: 0 0 #0000<i>;
+							--b-sdw: initial<i>;
+						`,
 						"2xs": `
-					box-shadow: var(--bx-sdw)<i>;
-					--b-sdw: var(--b-sdw-2xs)<i>;
-				`,
+							box-shadow: var(--bx-sdw)<i>;
+							--b-sdw: var(--b-sdw-2xs)<i>;
+						`,
 						xs: `
-					box-shadow: var(--bx-sdw)<i>;
-					--b-sdw: var(--b-sdw-xs)<i>;
-				`,
+							box-shadow: var(--bx-sdw)<i>;
+							--b-sdw: var(--b-sdw-xs)<i>;
+						`,
 						sm: `
-					box-shadow: var(--bx-sdw)<i>;
-					--b-sdw: var(--b-sdw-sm)<i>;
-				`,
+							box-shadow: var(--bx-sdw)<i>;
+							--b-sdw: var(--b-sdw-sm)<i>;
+						`,
 						DEFAULT: `
-					box-shadow: var(--bx-sdw)<i>;
-					--b-sdw: var(--b-sdw-sm)<i>;
-				`,
+							box-shadow: var(--bx-sdw)<i>;
+							--b-sdw: var(--b-sdw-sm)<i>;
+						`,
 						md: `
-					box-shadow: var(--bx-sdw)<i>;
-					--b-sdw: var(--b-sdw-md)<i>;
-				`,
+							box-shadow: var(--bx-sdw)<i>;
+							--b-sdw: var(--b-sdw-md)<i>;
+						`,
 						lg: `
-					box-shadow: var(--bx-sdw)<i>;
-					--b-sdw: var(--b-sdw-lg)<i>;
-				`,
+							box-shadow: var(--bx-sdw)<i>;
+							--b-sdw: var(--b-sdw-lg)<i>;
+						`,
 						xl: `
-					box-shadow: var(--bx-sdw)<i>;
-					--b-sdw: var(--b-sdw-xl)<i>;
-				`,
+							box-shadow: var(--bx-sdw)<i>;
+							--b-sdw: var(--b-sdw-xl)<i>;
+						`,
 						"2xl": `
-					box-shadow: var(--bx-sdw)<i>;
-					--b-sdw: var(--b-sdw-2xl)<i>;
-				`,
+							box-shadow: var(--bx-sdw)<i>;
+							--b-sdw: var(--b-sdw-2xl)<i>;
+						`,
 					},
 				},
 

--- a/apps/docs/src/content/docs/properties/layout/show.mdx
+++ b/apps/docs/src/content/docs/properties/layout/show.mdx
@@ -1,12 +1,17 @@
 ---
 title: "Show Elements | @layout"
-description: "Show hidden elements in layout."
-keywords: ["layout", "show", "display", "visibility", "css"]
+description: "Show hidden elements in layout (use with `hide`)."
+keywords: ["layout", "show", "display", "visibility"]
 ---
 
-# show
+# Show Elements
 
-makes the element visible (use with `hide`)
+Show hidden elements in layout (use with `hide`).
+
+Usage:
+
+- `@layout show;`
+- `@layout show-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/layout/theme.mdx
+++ b/apps/docs/src/content/docs/properties/layout/theme.mdx
@@ -1,12 +1,16 @@
 ---
-title: "Theme Styles | @layout"
-description: "Apply themes to elements."
-keywords: ["layout", "theme", "styling", "color", "css"]
+title: "Color Scheme | @layout"
+description: "Apply browser's native dark/light themes to elements."
+keywords: ["layout", "theme", "styling", "color"]
 ---
 
-# theme
+# Color Scheme
 
-suggests light or dark theme for the page
+Apply browser's native dark/light theme to elements.
+
+Usage:
+
+- `@layout theme-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/list/align.mdx
+++ b/apps/docs/src/content/docs/properties/list/align.mdx
@@ -1,12 +1,18 @@
 ---
 title: "List Marker Alignment | @list"
 description: "Align list markers within lists."
-keywords: ["list", "align", "marker", "positioning", "css"]
+keywords: ["list", "align", "marker", "positioning"]
 ---
 
-# align
+# Align List Marker
 
-sets marker inside or outside list item
+Align list markers within lists.
+
+Usage:
+
+- `@list align-*;`
+- `@list align-marker;`
+- `@list align-text;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/list/index.mdx
+++ b/apps/docs/src/content/docs/properties/list/index.mdx
@@ -1,8 +1,7 @@
 ---
 title: "List Intent - List Styling"
 description:
-  "List styling with @list intent. List markers, styles, and list layout
-  utilities."
+  "List styling with @list intent. List markers alignment and styles utilities."
 keywords: ["@list", "list", "list style", "list items", "markers"]
 ---
 
@@ -12,7 +11,7 @@ List intent contains **list** items related utilities.
 
 Utilities available in `@list` intent are listed below.
 
-| Utility    | Description                             | Documentation                          |
-| ---------- | --------------------------------------- | -------------------------------------- |
-| `align-*`  | sets marker inside or outside list item | [align](/docs/properties/list/align)   |
-| `marker-*` | marker shape for list items             | [marker](/docs/properties/list/marker) |
+| Utility    | Description                      | Documentation                          |
+| ---------- | -------------------------------- | -------------------------------------- |
+| `align-*`  | Align list markers within lists. | [align](/docs/properties/list/align)   |
+| `marker-*` | Style list markers and bullets.  | [marker](/docs/properties/list/marker) |

--- a/apps/docs/src/content/docs/properties/list/marker.mdx
+++ b/apps/docs/src/content/docs/properties/list/marker.mdx
@@ -1,12 +1,23 @@
 ---
 title: "List Marker Style | @list"
 description: "Style list markers and bullets."
-keywords: ["list", "marker", "bullet", "style", "css"]
+keywords: ["list", "marker", "bullet", "style"]
 ---
 
-# marker
+# List Marker Style
 
-marker shape for list items
+Style list markers and bullets.
+
+Usage:
+
+- `@list marker-*;`
+
+<Alert variant="info">
+
+If using unicode or emoji as marker, you need to apply left (inline start)
+padding to `li`.
+
+</Alert>
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/live/caret.mdx
+++ b/apps/docs/src/content/docs/properties/live/caret.mdx
@@ -1,12 +1,16 @@
 ---
-title: "Caret Cursor Style | @live"
-description: "Style text input caret cursor."
-keywords: ["live", "caret", "cursor", "input", "css"]
+title: "Caret Style | @live"
+description: "Style text input caret (cursor) color."
+keywords: ["live", "caret", "cursor", "input"]
 ---
 
-# caret
+# Caret Style
 
-sets the text input cursor color
+Style text input caret (cursor) color.
+
+Usage:
+
+- `@live caret-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/live/cursor.mdx
+++ b/apps/docs/src/content/docs/properties/live/cursor.mdx
@@ -1,12 +1,16 @@
 ---
 title: "Cursor Style | @live"
-description: "Set cursor style on hover."
-keywords: ["live", "cursor", "interaction", "pointer", "css"]
+description: "Set cursor (mouse pointer) style on hover."
+keywords: ["live", "cursor", "interaction", "pointer"]
 ---
 
-# cursor
+# Cursor Style
 
-specifies the mouse pointer style
+Set cursor (mouse pointer) style on hover.
+
+Usage:
+
+- `@live cursor-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/live/events.mdx
+++ b/apps/docs/src/content/docs/properties/live/events.mdx
@@ -1,12 +1,16 @@
 ---
-title: "Event Handling | @live"
+title: "Pointer Events | @live"
 description: "Control user interaction event handling."
-keywords: ["live", "events", "interaction", "pointer", "css"]
+keywords: ["live", "events", "interaction", "pointer"]
 ---
 
-# events
+# Pointer Events
 
-controls if element reacts to mouse events
+Control user interaction event handling.
+
+Usage:
+
+- `@live events-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/live/index.mdx
+++ b/apps/docs/src/content/docs/properties/live/index.mdx
@@ -13,15 +13,15 @@ Live intent contains **user interaction** related utilities.
 
 Utilities available in `@live` intent are listed below.
 
-| Utility         | Description                                             | Documentation                                          |
-| --------------- | ------------------------------------------------------- | ------------------------------------------------------ |
-| `caret-*`       | sets the text input cursor color                        | [caret](/docs/properties/live/caret)                   |
-| `cursor-*`      | specifies the mouse pointer style                       | [cursor](/docs/properties/live/cursor)                 |
-| `events-*`      | controls if element reacts to mouse events              | [events](/docs/properties/live/events)                 |
-| `outline-*`     | draws a line around an element without affecting layout | [outline](/docs/properties/live/outline)               |
-| `scroll-*`      | controls smooth or instant scrolling                    | [scroll](/docs/properties/live/scroll)                 |
-| `scroll-m*`     | margin around element for snapping or scrolling         | [scroll margin](/docs/properties/live/scroll-margin)   |
-| `scroll-p*`     | padding around element for snapping or scrolling        | [scroll padding](/docs/properties/live/scroll-padding) |
-| `scroll-snap-*` | controls snap points when scrolling a container         | [scroll snap](/docs/properties/live/scroll-snap)       |
-| `select-*`      | controls if text can be selected by user                | [select](/docs/properties/live/select)                 |
-| `touch-*`       | controls how touch gestures are handled                 | [touch](/docs/properties/live/touch)                   |
+| Utility         | Description                                                              | Documentation                                    |
+| --------------- | ------------------------------------------------------------------------ | ------------------------------------------------ |
+| `caret-*`       | Style text input caret (cursor) color.                                   | [caret](/docs/properties/live/caret)             |
+| `cursor-*`      | Set cursor (mouse pointer) style on hover.                               | [cursor](/docs/properties/live/cursor)           |
+| `events-*`      | Control user interaction event handling.                                 | [events](/docs/properties/live/events)           |
+| `outline-*`     | Set element outline styling, thickness (width), style, color and offset. | [outline](/docs/properties/live/outline)         |
+| `scroll-*`      | Control scroll behavior and other properties.                            | [scroll](/docs/properties/live/scroll)           |
+| `scroll-m*`     | Set spacing around element (margin) for snapping or scrolling.           | [scroll-m](/docs/properties/live/scroll-m)       |
+| `scroll-p*`     | Set spacing inside element (padding) for snapping or scrolling.          | [scroll-p](/docs/properties/live/scroll-p)       |
+| `scroll-snap-*` | Controls snap points when scrolling a container.                         | [scroll-snap](/docs/properties/live/scroll-snap) |
+| `select-*`      | Control text selection behavior.                                         | [select](/docs/properties/live/select)           |
+| `touch-*`       | Control touch interaction behavior.                                      | [touch](/docs/properties/live/touch)             |

--- a/apps/docs/src/content/docs/properties/live/meta.json
+++ b/apps/docs/src/content/docs/properties/live/meta.json
@@ -4,17 +4,25 @@
 	"label": "@live",
 	"title": "live intent",
 	"items": [
-		{
-			"name": "caret",
-			"label": "caret color"
-		},
+		"caret",
 		"cursor",
 		"events",
 		"outline",
 		"scroll",
-		"scroll-margin",
-		"scroll-padding",
-		"scroll-snap",
+		{
+			"name": "scroll-m",
+			"label": "scroll-m",
+			"title": "scroll margin"
+		},
+		{
+			"name": "scroll-p",
+			"label": "scroll-p",
+			"title": "scroll padding"
+		},
+		{
+			"name": "scroll-snap",
+			"label": "scroll-snap"
+		},
 		"select",
 		"touch"
 	]

--- a/apps/docs/src/content/docs/properties/live/outline.mdx
+++ b/apps/docs/src/content/docs/properties/live/outline.mdx
@@ -1,12 +1,21 @@
 ---
-title: "Outline Style | @live"
-description: "Set element outline styling."
-keywords: ["live", "outline", "border", "focus", "css"]
+title: "Outline | @live"
+description:
+  "Set element outline styling, thickness (width), style, color and offset."
+keywords: ["live", "outline", "border", "focus"]
 ---
 
-# outline
+# Outline
 
-draws a line around an element without affecting layout
+Set element outline styling, thickness (width), style, color and offset.
+
+Usage:
+
+- `@live outline-*;`
+- `@live outline-thick-*;`
+- `@live outline-style-*;`
+- `@live outline-color-*;`
+- `@live outline-offset-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/live/scroll-m.mdx
+++ b/apps/docs/src/content/docs/properties/live/scroll-m.mdx
@@ -1,12 +1,28 @@
 ---
-title: "Scroll Padding | @live"
-description: "Set scroll padding spacing around elements."
-keywords: ["live", "scroll", "padding", "spacing", "css"]
+title: "Scroll Margin | @live"
+description: "Set spacing around element (margin) for snapping or scrolling."
+keywords: ["live", "scroll", "margin", "spacing"]
 ---
 
-# scroll padding
+# Scroll Margin
 
-padding around element for snapping or scrolling
+Set spacing around element (margin) for snapping or scrolling.
+
+Usage:
+
+- `@live scroll-m-*;`
+- `@live scroll-mt-*;`
+- `@live scroll-mb-*;`
+- `@live scroll-ml-*;`
+- `@live scroll-mr-*;`
+- `@live scroll-mx-*;`
+- `@live scroll-my-*;`
+- `@live scroll-mbl-*;`
+- `@live scroll-mbls-*;`
+- `@live scroll-mble-*;`
+- `@live scroll-mi-*;`
+- `@live scroll-mis-*;`
+- `@live scroll-mie-*;`
 
 <Alert variant="info">
 
@@ -28,86 +44,86 @@ const shilpConfig = {
 	properties: {
 		live: {
 			scroll: {
-				p: {
-					property: "scroll-padding: <n><v><i>;",
+				m: {
+					property: "scroll-margin: <n><v><i>;",
 					resolve: "spacing",
 					themeKey: "spacingPixels",
 					values: {},
 				},
-				pt: {
-					property: "scroll-padding-top: <n><v><i>;",
+				mt: {
+					property: "scroll-margin-top: <n><v><i>;",
 					resolve: "spacing",
 					themeKey: "spacingPixels",
 					values: {},
 				},
-				pr: {
-					property: "scroll-padding-right: <n><v><i>;",
+				mr: {
+					property: "scroll-margin-right: <n><v><i>;",
 					resolve: "spacing",
 					themeKey: "spacingPixels",
 					values: {},
 				},
-				pb: {
-					property: "scroll-padding-bottom: <n><v><i>;",
+				mb: {
+					property: "scroll-margin-bottom: <n><v><i>;",
 					resolve: "spacing",
 					themeKey: "spacingPixels",
 					values: {},
 				},
-				pl: {
-					property: "scroll-padding-left: <n><v><i>;",
+				ml: {
+					property: "scroll-margin-left: <n><v><i>;",
 					resolve: "spacing",
 					themeKey: "spacingPixels",
 					values: {},
 				},
-				px: {
+				mx: {
 					property: `
-						scroll-padding-left: <n><v><i>;
-            scroll-padding-right: <n><v><i>;
+						scroll-margin-left: <n><v><i>;
+            scroll-margin-right: <n><v><i>;
           `,
 					resolve: "spacing",
 					themeKey: "spacingPixels",
 					values: {},
 				},
-				py: {
+				my: {
 					property: `
-						scroll-padding-top: <n><v><i>;
-            scroll-padding-bottom: <n><v><i>;
+            scroll-margin-top: <n><v><i>;
+            scroll-margin-bottom: <n><v><i>;
           `,
 					resolve: "spacing",
 					themeKey: "spacingPixels",
 					values: {},
 				},
-				pbl: {
-					property: "scroll-padding-block: <n><v><i>",
+				mbl: {
+					property: "scroll-margin-block: <n><v><i>",
 					resolve: "spacing",
 					themeKey: "spacingPixels",
 					values: {},
 				},
-				pbls: {
-					property: "scroll-padding-block-start: <n><v><i>;",
+				mbls: {
+					property: "scroll-margin-block-start: <n><v><i>;",
 					resolve: "spacing",
 					themeKey: "spacingPixels",
 					values: {},
 				},
-				pble: {
-					property: "scroll-padding-block-end: <n><v><i>;",
+				mble: {
+					property: "scroll-margin-block-end: <n><v><i>;",
 					resolve: "spacing",
 					themeKey: "spacingPixels",
 					values: {},
 				},
-				pi: {
-					property: "scroll-padding-inline: <n><v><i>",
+				mi: {
+					property: "scroll-margin-inline: <n><v><i>",
 					resolve: "spacing",
 					themeKey: "spacingPixels",
 					values: {},
 				},
-				pis: {
-					property: "scroll-padding-inline-start: <n><v><i>;",
+				mis: {
+					property: "scroll-margin-inline-start: <n><v><i>;",
 					resolve: "spacing",
 					themeKey: "spacingPixels",
 					values: {},
 				},
-				pie: {
-					property: "scroll-padding-inline-end: <n><v><i>;",
+				mie: {
+					property: "scroll-margin-inline-end: <n><v><i>;",
 					resolve: "spacing",
 					themeKey: "spacingPixels",
 					values: {},

--- a/apps/docs/src/content/docs/properties/live/scroll-p.mdx
+++ b/apps/docs/src/content/docs/properties/live/scroll-p.mdx
@@ -1,12 +1,28 @@
 ---
-title: "Scroll Margin | @live"
-description: "Set scroll margin spacing around elements."
-keywords: ["live", "scroll", "margin", "spacing", "css"]
+title: "Scroll Padding | @live"
+description: "Set spacing inside element (padding) for snapping or scrolling."
+keywords: ["live", "scroll", "padding", "spacing"]
 ---
 
-# scroll margin
+# Scroll Padding
 
-margin around element for snapping or scrolling
+Set spacing inside element (padding) for snapping or scrolling.
+
+Usage:
+
+- `@live scroll-p-*;`
+- `@live scroll-pt-*;`
+- `@live scroll-pb-*;`
+- `@live scroll-pl-*;`
+- `@live scroll-pr-*;`
+- `@live scroll-px-*;`
+- `@live scroll-py-*;`
+- `@live scroll-pbl-*;`
+- `@live scroll-pbls-*;`
+- `@live scroll-pble-*;`
+- `@live scroll-pi-*;`
+- `@live scroll-pis-*;`
+- `@live scroll-pie-*;`
 
 <Alert variant="info">
 
@@ -28,86 +44,86 @@ const shilpConfig = {
 	properties: {
 		live: {
 			scroll: {
-				m: {
-					property: "scroll-margin: <n><v><i>;",
+				p: {
+					property: "scroll-padding: <n><v><i>;",
 					resolve: "spacing",
 					themeKey: "spacingPixels",
 					values: {},
 				},
-				mt: {
-					property: "scroll-margin-top: <n><v><i>;",
+				pt: {
+					property: "scroll-padding-top: <n><v><i>;",
 					resolve: "spacing",
 					themeKey: "spacingPixels",
 					values: {},
 				},
-				mr: {
-					property: "scroll-margin-right: <n><v><i>;",
+				pr: {
+					property: "scroll-padding-right: <n><v><i>;",
 					resolve: "spacing",
 					themeKey: "spacingPixels",
 					values: {},
 				},
-				mb: {
-					property: "scroll-margin-bottom: <n><v><i>;",
+				pb: {
+					property: "scroll-padding-bottom: <n><v><i>;",
 					resolve: "spacing",
 					themeKey: "spacingPixels",
 					values: {},
 				},
-				ml: {
-					property: "scroll-margin-left: <n><v><i>;",
+				pl: {
+					property: "scroll-padding-left: <n><v><i>;",
 					resolve: "spacing",
 					themeKey: "spacingPixels",
 					values: {},
 				},
-				mx: {
+				px: {
 					property: `
-						scroll-margin-left: <n><v><i>;
-            scroll-margin-right: <n><v><i>;
+						scroll-padding-left: <n><v><i>;
+            scroll-padding-right: <n><v><i>;
           `,
 					resolve: "spacing",
 					themeKey: "spacingPixels",
 					values: {},
 				},
-				my: {
+				py: {
 					property: `
-            scroll-margin-top: <n><v><i>;
-            scroll-margin-bottom: <n><v><i>;
+						scroll-padding-top: <n><v><i>;
+            scroll-padding-bottom: <n><v><i>;
           `,
 					resolve: "spacing",
 					themeKey: "spacingPixels",
 					values: {},
 				},
-				mbl: {
-					property: "scroll-margin-block: <n><v><i>",
+				pbl: {
+					property: "scroll-padding-block: <n><v><i>",
 					resolve: "spacing",
 					themeKey: "spacingPixels",
 					values: {},
 				},
-				mbls: {
-					property: "scroll-margin-block-start: <n><v><i>;",
+				pbls: {
+					property: "scroll-padding-block-start: <n><v><i>;",
 					resolve: "spacing",
 					themeKey: "spacingPixels",
 					values: {},
 				},
-				mble: {
-					property: "scroll-margin-block-end: <n><v><i>;",
+				pble: {
+					property: "scroll-padding-block-end: <n><v><i>;",
 					resolve: "spacing",
 					themeKey: "spacingPixels",
 					values: {},
 				},
-				mi: {
-					property: "scroll-margin-inline: <n><v><i>",
+				pi: {
+					property: "scroll-padding-inline: <n><v><i>",
 					resolve: "spacing",
 					themeKey: "spacingPixels",
 					values: {},
 				},
-				mis: {
-					property: "scroll-margin-inline-start: <n><v><i>;",
+				pis: {
+					property: "scroll-padding-inline-start: <n><v><i>;",
 					resolve: "spacing",
 					themeKey: "spacingPixels",
 					values: {},
 				},
-				mie: {
-					property: "scroll-margin-inline-end: <n><v><i>;",
+				pie: {
+					property: "scroll-padding-inline-end: <n><v><i>;",
 					resolve: "spacing",
 					themeKey: "spacingPixels",
 					values: {},

--- a/apps/docs/src/content/docs/properties/live/scroll-snap.mdx
+++ b/apps/docs/src/content/docs/properties/live/scroll-snap.mdx
@@ -1,12 +1,18 @@
 ---
 title: "Scroll Snap | @live"
-description: "Enable scroll snap behavior on containers."
-keywords: ["live", "scroll", "snap", "behavior", "css"]
+description: "Controls snap points when scrolling a container."
+keywords: ["live", "scroll", "snap", "behavior"]
 ---
 
-# scroll snap
+# Scroll Snap
 
-controls snap points when scrolling a container
+Controls snap points when scrolling a container.
+
+Usage:
+
+- `@live scroll-snap-*;`
+- `@live scroll-snap-align-*;`
+- `@live scroll-snap-stop-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/live/scroll.mdx
+++ b/apps/docs/src/content/docs/properties/live/scroll.mdx
@@ -1,12 +1,18 @@
 ---
 title: "Scroll Behavior | @live"
-description: "Control scroll behavior and properties."
-keywords: ["live", "scroll", "behavior", "smooth", "css"]
+description: "Control scroll behavior and other properties."
+keywords: ["live", "scroll", "behavior", "smooth"]
 ---
 
-# scroll
+# Scroll Behaviour
 
-controls smooth or instant scrolling
+Control scroll behavior and other properties.
+
+Usage:
+
+- `@live scroll-*;`
+- `@live scroll-auto;`
+- `@live scroll-smooth;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/live/select.mdx
+++ b/apps/docs/src/content/docs/properties/live/select.mdx
@@ -1,12 +1,16 @@
 ---
-title: "Text Selection | @live"
+title: "Text Selection Type | @live"
 description: "Control text selection behavior."
-keywords: ["live", "select", "selection", "user", "css"]
+keywords: ["live", "select", "selection", "user"]
 ---
 
-# select
+# Text Selection Type
 
-controls if text can be selected by user
+Control text selection behavior.
+
+Usage:
+
+- `@live select-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/live/touch.mdx
+++ b/apps/docs/src/content/docs/properties/live/touch.mdx
@@ -1,12 +1,16 @@
 ---
 title: "Touch Interaction | @live"
 description: "Control touch interaction behavior."
-keywords: ["live", "touch", "interaction", "mobile", "css"]
+keywords: ["live", "touch", "interaction", "mobile"]
 ---
 
-# touch
+# Touch Interactions
 
-controls how touch gestures are handled
+Control touch interaction behavior.
+
+Usage:
+
+- `@live touch-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/mask/clip.mdx
+++ b/apps/docs/src/content/docs/properties/mask/clip.mdx
@@ -1,12 +1,16 @@
 ---
 title: "Mask Clip | @mask"
 description: "Define mask clip area within element."
-keywords: ["mask", "clip", "clipping", "area", "css"]
+keywords: ["mask", "clip", "clipping", "area"]
 ---
 
-# clip
+# Mask Clip
 
-area the mask affects on the element
+Define mask clip area within element.
+
+Usage:
+
+- `@mask clip-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/mask/combine.mdx
+++ b/apps/docs/src/content/docs/properties/mask/combine.mdx
@@ -1,12 +1,16 @@
 ---
-title: "Mask Combination | @mask"
+title: "Combine Masks | @mask"
 description: "Combine multiple masks on element."
-keywords: ["mask", "combine", "multiple", "layer", "css"]
+keywords: ["mask", "combine", "multiple", "layer"]
 ---
 
-# combine
+# Combine Masks
 
-specifies how multiple mask layers combine
+Combine multiple masks on element.
+
+Usage:
+
+- `@mask combine-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/mask/gradient.mdx
+++ b/apps/docs/src/content/docs/properties/mask/gradient.mdx
@@ -1,12 +1,28 @@
 ---
-title: "Gradient Mask | @mask"
-description: "Apply gradient masks to elements."
-keywords: ["mask", "gradient", "linear", "radial", "css"]
+title: "Gradient Color Mask | @mask"
+description: "Apply gradient as a mask to elements."
+keywords: ["mask", "gradient", "linear", "radial"]
 ---
 
-# gradient
+# Gradient Color Mask
 
-applies a gradient as a mask to an element
+Apply gradient as a mask to elements.
+
+Usage:
+
+- `@mask gradient-*;`
+- `@mask gradient-linear-*;`
+- `@mask gradient-radial-*;`
+- `@mask gradient-conic-*;`
+
+<Alert variant="danger">
+
+Gradient color mask uses `mask-image` property.
+
+So, if you are using `@mask img-*;` then conflict will be created. You need to
+choose a stratagey to work with both.
+
+</Alert>
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/mask/img.mdx
+++ b/apps/docs/src/content/docs/properties/mask/img.mdx
@@ -1,12 +1,25 @@
 ---
 title: "Mask Image | @mask"
-description: "Set mask images from URLs."
-keywords: ["mask", "image", "mask-image", "url", "css"]
+description: "Specifies an image to use as a mask."
+keywords: ["mask", "image", "mask-image", "url"]
 ---
 
-# img
+# Mask Image
 
-specifies an image to use as a mask
+Specifies an image to use as a mask.
+
+Usage:
+
+- `@mask img-*;`
+
+<Alert variant="danger">
+
+Gradient color mask uses `mask-image` property.
+
+So, if you are using `@mask gradient-*;` then conflict will be created. You need
+to choose a stratagey to work with both.
+
+</Alert>
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/mask/index.mdx
+++ b/apps/docs/src/content/docs/properties/mask/index.mdx
@@ -12,15 +12,15 @@ Mask intent contains **element's masking** related utilities.
 
 Utilities available in `@mask` intent are listed below.
 
-| Utility      | Description                                          | Documentation                              |
-| ------------ | ---------------------------------------------------- | ------------------------------------------ |
-| `clip-*`     | area the mask affects on the element                 | [clip](/docs/properties/mask/clip)         |
-| `combine-*`  | specifies how multiple mask layers combine           | [combine](/docs/properties/mask/combine)   |
-| `gradient-*` | applies a gradient as a mask to an element           | [gradient](/docs/properties/mask/gradient) |
-| `img-*`      | specifies an image to use as a mask                  | [image](/docs/properties/mask/image)       |
-| `mode-*`     | sets how the mask image is applied                   | [mode](/docs/properties/mask/mode)         |
-| `origin-*`   | defines the positioning area for the mask            | [origin](/docs/properties/mask/origin)     |
-| `position-*` | position of the mask, relative to `mask-origin`      | [position](/docs/properties/mask/position) |
-| `repeat-*`   | ontrols how the mask image is repeated               | [repeat](/docs/properties/mask/repeat)     |
-| `size-*`     | size of the mask image                               | [size](/docs/properties/mask/size)         |
-| `type-*`     | defines whether mask uses brightness or transparency | [type](/docs/properties/mask/type)         |
+| Utility      | Description                                             | Documentation                              |
+| ------------ | ------------------------------------------------------- | ------------------------------------------ |
+| `clip-*`     | Define mask clip area within element.                   | [clip](/docs/properties/mask/clip)         |
+| `combine-*`  | Combine multiple masks on element.                      | [combine](/docs/properties/mask/combine)   |
+| `gradient-*` | Apply gradient as a mask to elements.                   | [gradient](/docs/properties/mask/gradient) |
+| `img-*`      | Specifies an image to use as a mask.                    | [img](/docs/properties/mask/img)           |
+| `mode-*`     | Set mask blend mode for compositing or layering effect. | [mode](/docs/properties/mask/mode)         |
+| `origin-*`   | Set mask origin position.                               | [origin](/docs/properties/mask/origin)     |
+| `position-*` | Position mask image on element relative to mask origin. | [position](/docs/properties/mask/position) |
+| `repeat-*`   | Control mask image repetition.                          | [repeat](/docs/properties/mask/repeat)     |
+| `size-*`     | Set mask image size.                                    | [size](/docs/properties/mask/size)         |
+| `type-*`     | Define mask type for layering effect.                   | [type](/docs/properties/mask/type)         |

--- a/apps/docs/src/content/docs/properties/mask/meta.json
+++ b/apps/docs/src/content/docs/properties/mask/meta.json
@@ -7,7 +7,7 @@
 		"clip",
 		"combine",
 		"gradient",
-		"image",
+		"img",
 		"mode",
 		"origin",
 		"position",

--- a/apps/docs/src/content/docs/properties/mask/mode.mdx
+++ b/apps/docs/src/content/docs/properties/mask/mode.mdx
@@ -1,12 +1,16 @@
 ---
 title: "Mask Mode | @mask"
-description: "Set mask blend mode for compositing."
-keywords: ["mask", "mode", "blend", "compositing", "css"]
+description: "Set mask blend mode for compositing or layering effect."
+keywords: ["mask", "mode", "blend", "compositing", "layering effect"]
 ---
 
-# mode
+# Mask Mode
 
-sets how the mask image is applied
+Set mask blend mode for compositing or layering effect.\
+
+Usage:
+
+- `@mask mode-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/mask/origin.mdx
+++ b/apps/docs/src/content/docs/properties/mask/origin.mdx
@@ -1,12 +1,16 @@
 ---
 title: "Mask Origin | @mask"
 description: "Set mask origin position."
-keywords: ["mask", "origin", "position", "reference", "css"]
+keywords: ["mask", "origin", "position", "reference"]
 ---
 
-# origin
+# Mask Origin
 
-defines the positioning area for the mask
+Set mask origin position.
+
+Usage:
+
+- `@mask origin-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/mask/position.mdx
+++ b/apps/docs/src/content/docs/properties/mask/position.mdx
@@ -1,12 +1,18 @@
 ---
-title: "Mask Position | @mask"
-description: "Position mask image on element."
-keywords: ["mask", "position", "placement", "offset", "css"]
+title: "Mask Image Position | @mask"
+description: "Position mask image on element relative to mask origin."
+keywords: ["mask", "position", "placement", "offset"]
 ---
 
-# position
+# Mask Image Position
 
-position of the mask, relative to `mask-origin`
+Position mask image on element relative to mask origin.
+
+Usage:
+
+- `@mask position-*;`
+- `@mask position-x-*;`
+- `@mask position-y-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/mask/repeat.mdx
+++ b/apps/docs/src/content/docs/properties/mask/repeat.mdx
@@ -1,12 +1,16 @@
 ---
-title: "Mask Repeat | @mask"
+title: "Mask Image Repeat | @mask"
 description: "Control mask image repetition."
-keywords: ["mask", "repeat", "tiling", "pattern", "css"]
+keywords: ["mask", "repeat", "tiling", "pattern"]
 ---
 
-# repeat
+# Mask Image Repeat
 
-ontrols how the mask image is repeated
+Control mask image repetition.
+
+Usage:
+
+- `@mask repeat-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/mask/size.mdx
+++ b/apps/docs/src/content/docs/properties/mask/size.mdx
@@ -1,12 +1,16 @@
 ---
-title: "Mask Size | @mask"
+title: "Mask Image Size | @mask"
 description: "Set mask image size."
-keywords: ["mask", "size", "dimension", "width", "css"]
+keywords: ["mask", "size", "dimension", "width"]
 ---
 
-# size
+# Maks Image Size
 
-size of the mask image
+Set mask image size.
+
+Usage:
+
+- `@mask size-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/mask/type.mdx
+++ b/apps/docs/src/content/docs/properties/mask/type.mdx
@@ -1,12 +1,16 @@
 ---
 title: "Mask Type | @mask"
-description: "Define mask type for clipping."
-keywords: ["mask", "type", "clipping", "alpha", "css"]
+description: "Define mask type for layering effect."
+keywords: ["mask", "type", "clipping", "alpha"]
 ---
 
-# type
+# Mask Type
 
-defines whether mask uses brightness or transparency
+Define mask type for layering effect.
+
+Usage:
+
+- `@mask type-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/phase/delay.mdx
+++ b/apps/docs/src/content/docs/properties/phase/delay.mdx
@@ -1,12 +1,16 @@
 ---
-title: "Phase Animation Delay | @phase"
-description: "Control phase animation delay timing."
-keywords: ["phase", "delay", "animation", "timing", "css"]
+title: "Transition Delay | @phase"
+description: "Control delay time before transition starts."
+keywords: ["phase", "delay", "animation", "timing"]
 ---
 
-# delay
+# Transition Delay
 
-delay before a transition starts
+Control delay time before transition starts.
+
+Usage:
+
+- `@phase delay-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/phase/duration.mdx
+++ b/apps/docs/src/content/docs/properties/phase/duration.mdx
@@ -1,12 +1,16 @@
 ---
-title: "Phase Animation Duration | @phase"
-description: "Set phase animation duration."
-keywords: ["phase", "duration", "animation", "timing", "css"]
+title: "Transition Duration | @phase"
+description: "Set how long a transition lasts."
+keywords: ["phase", "duration", "animation", "timing"]
 ---
 
 # duration
 
-how long a transition takes
+Set how long a transition lasts.
+
+Usage:
+
+- `@phase duration-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/phase/flow.mdx
+++ b/apps/docs/src/content/docs/properties/phase/flow.mdx
@@ -1,12 +1,16 @@
 ---
-title: "Phase Animation Flow | @phase"
-description: "Control phase animation flow."
-keywords: ["phase", "flow", "animation", "sequence", "css"]
+title: "Transition Flow OR Bezier Curve | @phase"
+description: "Control flow or bezier-curve for transition."
+keywords: ["phase", "flow", "animation", "sequence"]
 ---
 
-# flow
+# Transition Flow or Bezier Curve
 
-speed curve of a transition
+Control flow or bezier-curve for transition.
+
+Usage:
+
+- `@phase flow-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/phase/for.mdx
+++ b/apps/docs/src/content/docs/properties/phase/for.mdx
@@ -1,12 +1,16 @@
 ---
-title: "Phase Target Selector | @phase"
+title: "Transition Properties | @phase"
 description: "Define phase target elements."
-keywords: ["phase", "for", "selector", "target", "css"]
+keywords: ["phase", "for", "selector", "target"]
 ---
 
-# for
+# Transition Properties
 
 specifies which CSS properties will transition
+
+Usage:
+
+- `@phase for-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/phase/index.mdx
+++ b/apps/docs/src/content/docs/properties/phase/index.mdx
@@ -1,8 +1,8 @@
 ---
 title: "Phase Intent - Transitions"
 description:
-  "Transition styling with @phase intent. Control transitions, timing, and
-  animation properties."
+  "Transition styling with @phase intent. Control transitions, timing, speed,
+  and other properties."
 keywords: ["@phase", "transition", "timing function", "duration", "animation"]
 ---
 
@@ -12,10 +12,10 @@ Phase intent contains element's `transition` related utilities.
 
 Utilities available in `@phase` intent are listed below.
 
-| Utility      | Description                                    | Documentation                               |
-| ------------ | ---------------------------------------------- | ------------------------------------------- |
-| `delay-*`    | delay before a transition starts               | [delay](/docs/properties/phase/delay)       |
-| `duration-*` | how long a transition takes                    | [duration](/docs/properties/phase/duration) |
-| `flow-*`     | speed curve of a transition                    | [flow](/docs/properties/phase/flow)         |
-| `for-*`      | specifies which CSS properties will transition | [for](/docs/properties/phase/for)           |
-| `preset-*`   | `transition` property                          | [preset](/docs/properties/phase/preset)     |
+| Utility      | Description                                            | Documentation                               |
+| ------------ | ------------------------------------------------------ | ------------------------------------------- |
+| `delay-*`    | Control delay time before transition starts.           | [delay](/docs/properties/phase/delay)       |
+| `duration-*` | Set how long a transition lasts.                       | [duration](/docs/properties/phase/duration) |
+| `flow-*`     | Control flow or bezier-curve for transition.           | [flow](/docs/properties/phase/flow)         |
+| `for-*`      | specifies which CSS properties will transition         | [for](/docs/properties/phase/for)           |
+| `preset-*`   | Use phase, transition combinations for common effects. | [preset](/docs/properties/phase/preset)     |

--- a/apps/docs/src/content/docs/properties/phase/preset.mdx
+++ b/apps/docs/src/content/docs/properties/phase/preset.mdx
@@ -1,12 +1,16 @@
 ---
-title: "Phase Animation Presets | @phase"
-description: "Use phase animation presets."
-keywords: ["phase", "preset", "template", "animation", "css"]
+title: "Transition Presets | @phase"
+description: "Use phase, transition combinations for common effects."
+keywords: ["phase", "preset", "template", "animation"]
 ---
 
-# preset
+# Transition Presets
 
-`transition` property
+Use phase, transition combinations for common effects.
+
+Usage:
+
+- `@phase preset-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/position/bottom.mdx
+++ b/apps/docs/src/content/docs/properties/position/bottom.mdx
@@ -1,12 +1,17 @@
 ---
 title: "Bottom Offset | @position"
-description: "Set bottom positioning offset for elements."
-keywords: ["position", "bottom", "offset", "coordinate", "css"]
+description:
+  "Set positioned element's bottom side distance or offset from the parent."
+keywords: ["position", "bottom", "offset", "coordinate"]
 ---
 
-# bottom
+# Bottom Offset
 
-positioned element's bottom side distance from the parent
+Set positioned element's bottom side distance or offset from the parent.
+
+Usage:
+
+- `@position bottom-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/position/index.mdx
+++ b/apps/docs/src/content/docs/properties/position/index.mdx
@@ -1,8 +1,8 @@
 ---
 title: "Position Intent - Positioning Utilities"
 description:
-  "Positioning with @position intent. Absolute, relative, fixed, and sticky
-  positioning utilities."
+  "Positioning with @position intent. Positioned element's method (or type) and
+  offset (or distance) utilities."
 keywords:
   ["@position", "positioning", "absolute", "relative", "fixed", "sticky"]
 ---
@@ -13,13 +13,13 @@ Position intent contains **element's position** related utilities.
 
 Utilities available in `@position` intent are listed below.
 
-| Utility    | Description                                                    | Documentation                              |
-| ---------- | -------------------------------------------------------------- | ------------------------------------------ |
-| `is-*`     | element's is position related to parent                        | [is](/docs/properties/position/is)         |
-| `inset-*`  | Shorthand for top, right, bottom, left offsets                 | [inset](/docs/properties/position/inset)   |
-| `top-*`    | positioned element's top side distance from the parent         | [top](/docs/properties/position/top)       |
-| `bottom-*` | positioned element's bottom side distance from the parent      | [bottom](/docs/properties/position/bottom) |
-| `left-*`   | positioned element's left side distance from the parent        | [left](/docs/properties/position/left)     |
-| `right-*`  | positioned element's right side distance from the parent       | [right](/docs/properties/position/right)   |
-| `x-*`      | positioned element's horizontal sides distance from the parent | [x](/docs/properties/position/x)           |
-| `y-*`      | positioned element's vertical sides distance from the parent   | [y](/docs/properties/position/y)           |
+| Utility    | Description                                                                                   | Documentation                              |
+| ---------- | --------------------------------------------------------------------------------------------- | ------------------------------------------ |
+| `is-*`     | Set element's position method or type related to parent.                                      | [is](/docs/properties/position/is)         |
+| `inset-*`  | Set positioned element's distance or offset from all sides from the parent.                   | [inset](/docs/properties/position/inset)   |
+| `top-*`    | Set positioned element's top side distance or offset from the parent.                         | [top](/docs/properties/position/top)       |
+| `bottom-*` | Set positioned element's bottom side distance or offset from the parent.                      | [bottom](/docs/properties/position/bottom) |
+| `left-*`   | Set positioned element's left side distance or offset from the parent.                        | [left](/docs/properties/position/left)     |
+| `right-*`  | Set positioned element's right side distance or offset from the parent.                       | [right](/docs/properties/position/right)   |
+| `x-*`      | Set positioned element's right and left (horizontal) side distance or offset from the parent. | [x](/docs/properties/position/x)           |
+| `y-*`      | Set positioned element's top and bottom (vertical) side distance or offset from the parent.   | [y](/docs/properties/position/y)           |

--- a/apps/docs/src/content/docs/properties/position/inset.mdx
+++ b/apps/docs/src/content/docs/properties/position/inset.mdx
@@ -1,12 +1,23 @@
 ---
-title: "Inset Offsets | @position"
-description: "Set all inset positioning values."
-keywords: ["position", "inset", "offset", "shorthand", "css"]
+title: "Offset From All Sides | @position"
+description:
+  "Set positioned element's distance or offset from all sides from the parent."
+keywords: ["position", "inset", "offset", "shorthand"]
 ---
 
-# inset
+# Offset From All Sides
 
-Shorthand for top, right, bottom, left offsets
+Set positioned element's distance or offset from all sides from the parent.
+
+Usage:
+
+- `@position inset-*;`
+- `@position inset-block-*;`
+- `@position inset-block-start-*;`
+- `@position inset-block-end*;`
+- `@position inset-inline-*;`
+- `@position inset-inline-start-*;`
+- `@position inset-inline-end-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/position/is.mdx
+++ b/apps/docs/src/content/docs/properties/position/is.mdx
@@ -1,12 +1,16 @@
 ---
-title: "Position Type | @position"
-description: "Define positioning method type."
-keywords: ["position", "method", "absolute", "relative", "css"]
+title: "Position Method OR Type | @position"
+description: "Set element's position method or type related to parent."
+keywords: ["position", "method", "absolute", "relative"]
 ---
 
-# is
+# Position Method OR Type
 
-element's is position related to parent
+Set element's position method or type related to parent.
+
+Usage:
+
+- `@position is-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/position/left.mdx
+++ b/apps/docs/src/content/docs/properties/position/left.mdx
@@ -1,12 +1,17 @@
 ---
 title: "Left Offset | @position"
-description: "Set left positioning offset for elements."
-keywords: ["position", "left", "offset", "coordinate", "css"]
+description:
+  "Set positioned element's left side distance or offset from the parent."
+keywords: ["position", "left", "offset", "coordinate"]
 ---
 
-# left
+# Left Offset
 
-positioned element's left side distance from the parent
+Set positioned element's left side distance or offset from the parent.
+
+Usage:
+
+- `@position left-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/position/right.mdx
+++ b/apps/docs/src/content/docs/properties/position/right.mdx
@@ -1,12 +1,17 @@
 ---
 title: "Right Offset | @position"
-description: "Set right positioning offset for elements."
-keywords: ["position", "right", "offset", "coordinate", "css"]
+description:
+  "Set positioned element's right side distance or offset from the parent."
+keywords: ["position", "right", "offset", "coordinate"]
 ---
 
-# right
+# Right Offset
 
-positioned element's right side distance from the parent
+Set positioned element's right side distance or offset from the parent.
+
+Usage:
+
+- `@position right-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/position/top.mdx
+++ b/apps/docs/src/content/docs/properties/position/top.mdx
@@ -1,12 +1,17 @@
 ---
 title: "Top Offset | @position"
-description: "Set top positioning offset for elements."
-keywords: ["position", "top", "offset", "coordinate", "css"]
+description:
+  "Set positioned element's top side distance or offset from the parent."
+keywords: ["position", "top", "offset", "coordinate"]
 ---
 
-# top
+# Top Offset
 
-positioned element's top side distance from the parent
+Set positioned element's top side distance or offset from the parent.
+
+Usage:
+
+- `@position top-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/position/x.mdx
+++ b/apps/docs/src/content/docs/properties/position/x.mdx
@@ -1,12 +1,19 @@
 ---
 title: "Horizontal Offset | @position"
-description: "Set horizontal X-axis positioning offset."
-keywords: ["position", "x", "horizontal", "offset", "css"]
+description:
+  "Set positioned element's right and left (horizontal) side distance or offset
+  from the parent."
+keywords: ["position", "x", "horizontal", "offset"]
 ---
 
-# x
+# Horizontal Offset
 
-positioned element's horizontal sides distance from the parent
+Set positioned element's right and left (horizontal) side distance or offset
+from the parent.
+
+Usage:
+
+- `@position x-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/position/y.mdx
+++ b/apps/docs/src/content/docs/properties/position/y.mdx
@@ -1,12 +1,19 @@
 ---
 title: "Vertical Offset | @position"
-description: "Set vertical Y-axis positioning offset."
-keywords: ["position", "y", "vertical", "offset", "css"]
+description:
+  "Set positioned element's top and bottom (vertical) side distance or offset
+  from the parent."
+keywords: ["position", "y", "vertical", "offset"]
 ---
 
-# y
+# Vertical Offset
 
-positioned element's vertical sides distance from the parent
+Set positioned element's top and bottom (vertical) side distance or offset from
+the parent.
+
+Usage:
+
+- `@position y-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/size/h.mdx
+++ b/apps/docs/src/content/docs/properties/size/h.mdx
@@ -1,12 +1,16 @@
 ---
 title: "Height | @size"
-description: "Control element height dimension."
-keywords: ["size", "height", "dimension", "width", "css"]
+description: "Set element's height."
+keywords: ["size", "height", "dimension", "width"]
 ---
 
-# height
+# Height
 
-element’s height
+Set element's height.
+
+Usage:
+
+- `@size h-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/size/index.mdx
+++ b/apps/docs/src/content/docs/properties/size/index.mdx
@@ -1,8 +1,7 @@
 ---
 title: "Size Intent - Dimension Utilities"
 description:
-  "Sizing with @size intent. Width, height, aspect ratio, and dimension
-  utilities."
+  "Sizing with @size intent. Width and height (dimensions) utilities."
 keywords: ["@size", "width", "height", "dimensions", "aspect ratio", "sizing"]
 ---
 
@@ -12,10 +11,10 @@ Size intent contains **element's dimentions** related utilities.
 
 Utilities available in `@size` intent are listed below.
 
-| Utility | Description                                    | Documentation                            |
-| ------- | ---------------------------------------------- | ---------------------------------------- |
-| `h-*`   | element’s height                               | [height](/docs/properties/size/height)   |
-| `is-*`  | element’s height & width                       | [is](/docs/properties/size/is)           |
-| `max-*` | element’s maximum height and width             | [maximum](/docs/properties/size/maximum) |
-| `min-*` | controls min points when scrolling a container | [minimum](/docs/properties/size/minimum) |
-| `w-*`   | element’s height                               | [width](/docs/properties/size/width)     |
+| Utility | Description                                                     | Documentation                    |
+| ------- | --------------------------------------------------------------- | -------------------------------- |
+| `h-*`   | Set element's height.                                           | [h](/docs/properties/size/h)     |
+| `is-*`  | Set elements size (width & height) including block and inline.  | [is](/docs/properties/size/is)   |
+| `max-*` | Set maximum dimensions for elements including block and inline. | [max](/docs/properties/size/max) |
+| `min-*` | Set minimum dimensions for elements including block and inline. | [min](/docs/properties/size/min) |
+| `w-*`   | Set element's width.                                            | [w](/docs/properties/size/w)     |

--- a/apps/docs/src/content/docs/properties/size/is.mdx
+++ b/apps/docs/src/content/docs/properties/size/is.mdx
@@ -1,12 +1,18 @@
 ---
-title: "Width and Height | @size"
-description: "Define sizing method type."
-keywords: ["size", "method", "dimension", "unit", "css"]
+title: "Size (Width & Height) | @size"
+description: "Set elements size (width & height) including block and inline."
+keywords: ["size", "method", "dimension", "unit"]
 ---
 
-# is
+# Size
 
-element’s height & width
+Set elements size (width & height) including block and inline.
+
+Usage:
+
+- `@size is-*;`
+- `@size is-block-*;`
+- `@size is-inline-*;`
 
 <Alert variant="info">
 
@@ -30,9 +36,9 @@ const shilpConfig = {
 			is: {
 				DEFAULT: {
 					property: `
-				width: <v><i>;
-				height: <v><i>;
-			`,
+						width: <v><i>;
+						height: <v><i>;
+					`,
 					resolve: "spacing",
 					themeKey: "spacing",
 					values: {

--- a/apps/docs/src/content/docs/properties/size/max.mdx
+++ b/apps/docs/src/content/docs/properties/size/max.mdx
@@ -1,12 +1,20 @@
 ---
 title: "Maximum Size | @size"
-description: "Set maximum dimensions for elements."
-keywords: ["size", "maximum", "max", "constraint", "css"]
+description: "Set maximum dimensions for elements including block and inline."
+keywords: ["size", "maximum", "max", "constraint"]
 ---
 
-# maximum
+# Maximum Size
 
-element’s maximum height and width
+Set maximum dimensions for elements including block and inline.
+
+Usage:
+
+- `@size max-*;`
+- `@size max-w-*;`
+- `@size max-h-*;`
+- `@size max-block-*;`
+- `@size max-inline-*;`
 
 <Alert variant="info">
 
@@ -30,9 +38,9 @@ const shilpConfig = {
 			max: {
 				DEFAULT: {
 					property: `
-				max-width: <v><i>;
-				max-height: <v><i>;
-			`,
+						max-width: <v><i>;
+						max-height: <v><i>;
+					`,
 					resolve: "spacing",
 					themeKey: "spacing",
 					values: {

--- a/apps/docs/src/content/docs/properties/size/meta.json
+++ b/apps/docs/src/content/docs/properties/size/meta.json
@@ -3,5 +3,5 @@
 	"name": "index",
 	"label": "@size",
 	"title": "size intent",
-	"items": ["height", "is", "maximum", "minimum", "width"]
+	"items": ["h", "is", "max", "min", "w"]
 }

--- a/apps/docs/src/content/docs/properties/size/min.mdx
+++ b/apps/docs/src/content/docs/properties/size/min.mdx
@@ -1,12 +1,20 @@
 ---
 title: "Minimum Size | @size"
-description: "Set minimum dimensions for elements."
-keywords: ["size", "minimum", "min", "constraint", "css"]
+description: "Set maximum dimensions for elements including block and inline."
+keywords: ["size", "minimum", "min", "constraint"]
 ---
 
-# minimum
+# Minimum Size
 
-controls min points when scrolling a container
+Set maximum dimensions for elements including block and inline.
+
+Usage:
+
+- `@size min-*;`
+- `@size min-w-*;`
+- `@size min-h-*;`
+- `@size min-block-*;`
+- `@size min-inline-*;`
 
 <Alert variant="info">
 
@@ -30,9 +38,9 @@ const shilpConfig = {
 			min: {
 				DEFAULT: {
 					property: `
-				min-width: <v><i>;
-				min-height: <v><i>;
-			`,
+						min-width: <v><i>;
+						min-height: <v><i>;
+					`,
 					resolve: "spacing",
 					themeKey: "spacing",
 					values: {

--- a/apps/docs/src/content/docs/properties/size/w.mdx
+++ b/apps/docs/src/content/docs/properties/size/w.mdx
@@ -1,12 +1,16 @@
 ---
 title: "Width | @size"
-description: "Control element width dimension."
-keywords: ["size", "width", "dimension", "height", "css"]
+description: "Set element's width."
+keywords: ["size", "width", "dimension", "height"]
 ---
 
-# width
+# Width
 
-element’s height
+Set element's width.
+
+Usage:
+
+- `@size w-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/space/gap.mdx
+++ b/apps/docs/src/content/docs/properties/space/gap.mdx
@@ -1,12 +1,18 @@
 ---
-title: "Gap Spacing | @space"
-description: "Control gap spacing in flex and grid layouts."
-keywords: ["space", "gap", "spacing", "layout", "css"]
+title: "Spacing Between Items | @space"
+description: "Control spacing between items (flex, grid and multi-column)."
+keywords: ["space", "gap", "spacing", "layout"]
 ---
 
-# gap
+# Spacing Between Items
 
-spacing between items (flex, grid & multi-columns)
+Control spacing between items (flex, grid and multi-column).
+
+Usage:
+
+- `@space gap-*;`
+- `@space gap-x-*;`
+- `@space gap-y-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/space/index.mdx
+++ b/apps/docs/src/content/docs/properties/space/index.mdx
@@ -12,8 +12,8 @@ Space intent contains **element's spacing** related utilities.
 
 Utilities available in `@space` intent are listed below.
 
-| Utility     | Description                                        | Documentation                             |
-| ----------- | -------------------------------------------------- | ----------------------------------------- |
-| `gap-*`     | spacing between items (flex, grid & multi-columns) | [gap](/docs/properties/space/gap)         |
-| `margin-*`  | space outside an element                           | [margin](/docs/properties/space/margin)   |
-| `padding-*` | space inside an element                            | [padding](/docs/properties/space/padding) |
+| Utility | Description                                                  | Documentation                     |
+| ------- | ------------------------------------------------------------ | --------------------------------- |
+| `gap-*` | Control spacing between items (flex, grid and multi-column). | [gap](/docs/properties/space/gap) |
+| `m-*`   | Apply spacing around elements (margin).                      | [m](/docs/properties/space/m)     |
+| `p-*`   | Apply spacing inside elements (padding).                     | [p](/docs/properties/space/p)     |

--- a/apps/docs/src/content/docs/properties/space/m.mdx
+++ b/apps/docs/src/content/docs/properties/space/m.mdx
@@ -1,12 +1,28 @@
 ---
-title: "Padding | @space"
-description: "Apply padding spacing inside elements."
-keywords: ["space", "padding", "spacing", "distance", "css"]
+title: "Margin | @space"
+description: "Apply spacing around elements (margin)."
+keywords: ["space", "margin", "spacing", "distance"]
 ---
 
-# padding
+# Margin
 
-space inside an element
+Apply spacing around elements (margin).
+
+Usage:
+
+- `@space m-*;`
+- `@space mt-*;`
+- `@space mb-*;`
+- `@space ml-*;`
+- `@space mr-*;`
+- `@space mx-*;`
+- `@space my-*;`
+- `@space mbl-*;`
+- `@space mbls-*;`
+- `@space mble-*;`
+- `@space mi-*;`
+- `@space mis-*;`
+- `@space mie-*;`
 
 <Alert variant="info">
 
@@ -27,86 +43,86 @@ const shilpConfig = {
 
 	properties: {
 		space: {
-			p: {
-				property: "padding: <n><v><i>;",
+			m: {
+				property: "margin: <n><v><i>;",
 				resolve: "spacing",
 				themeKey: "spacingPixels",
 				values: {},
 			},
-			pt: {
-				property: "padding-top: <n><v><i>;",
+			mt: {
+				property: "margin-top: <n><v><i>;",
 				resolve: "spacing",
 				themeKey: "spacingPixels",
 				values: {},
 			},
-			pr: {
-				property: "padding-right: <n><v><i>;",
+			mr: {
+				property: "margin-right: <n><v><i>;",
 				resolve: "spacing",
 				themeKey: "spacingPixels",
 				values: {},
 			},
-			pb: {
-				property: "padding-bottom: <n><v><i>;",
+			mb: {
+				property: "margin-bottom: <n><v><i>;",
 				resolve: "spacing",
 				themeKey: "spacingPixels",
 				values: {},
 			},
-			pl: {
-				property: "padding-left: <n><v><i>;",
+			ml: {
+				property: "margin-left: <n><v><i>;",
 				resolve: "spacing",
 				themeKey: "spacingPixels",
 				values: {},
 			},
-			px: {
+			mx: {
 				property: `
-					padding-left: <n><v><i>;
-          padding-right: <n><v><i>;
+					margin-left: <n><v><i>;
+          margin-right: <n><v><i>;
         `,
 				resolve: "spacing",
 				themeKey: "spacingPixels",
 				values: {},
 			},
-			py: {
+			my: {
 				property: `
-					padding-top: <n><v><i>;
-          padding-bottom: <n><v><i>;
+					margin-top: <n><v><i>;
+          margin-bottom: <n><v><i>;
         `,
 				resolve: "spacing",
 				themeKey: "spacingPixels",
 				values: {},
 			},
-			pbl: {
-				property: "padding-block: <n><v><i>",
+			mbl: {
+				property: "margin-block: <n><v><i>",
 				resolve: "spacing",
 				themeKey: "spacingPixels",
 				values: {},
 			},
-			pbls: {
-				property: "padding-block-start: <n><v><i>;",
+			mbls: {
+				property: "margin-block-start: <n><v><i>;",
 				resolve: "spacing",
 				themeKey: "spacingPixels",
 				values: {},
 			},
-			pble: {
-				property: "padding-block-end: <n><v><i>;",
+			mble: {
+				property: "margin-block-end: <n><v><i>;",
 				resolve: "spacing",
 				themeKey: "spacingPixels",
 				values: {},
 			},
-			pi: {
-				property: "padding-inline: <n><v><i>",
+			mi: {
+				property: "margin-inline: <n><v><i>",
 				resolve: "spacing",
 				themeKey: "spacingPixels",
 				values: {},
 			},
-			pis: {
-				property: "padding-inline-start: <n><v><i>;",
+			mis: {
+				property: "margin-inline-start: <n><v><i>;",
 				resolve: "spacing",
 				themeKey: "spacingPixels",
 				values: {},
 			},
-			pie: {
-				property: "padding-inline-end: <n><v><i>;",
+			mie: {
+				property: "margin-inline-end: <n><v><i>;",
 				resolve: "spacing",
 				themeKey: "spacingPixels",
 				values: {},

--- a/apps/docs/src/content/docs/properties/space/meta.json
+++ b/apps/docs/src/content/docs/properties/space/meta.json
@@ -3,5 +3,5 @@
 	"name": "index",
 	"label": "@space",
 	"title": "space intent",
-	"items": ["gap", "margin", "padding"]
+	"items": ["gap", "m", "p"]
 }

--- a/apps/docs/src/content/docs/properties/space/p.mdx
+++ b/apps/docs/src/content/docs/properties/space/p.mdx
@@ -1,12 +1,28 @@
 ---
-title: "Margin | @space"
-description: "Apply margin spacing around elements."
-keywords: ["space", "margin", "spacing", "distance", "css"]
+title: "Padding | @space"
+description: "Apply spacing inside elements (padding)."
+keywords: ["space", "padding", "spacing", "distance"]
 ---
 
-# margin
+# Padding
 
-space outside an element
+Apply spacing inside elements (padding).
+
+Usage:
+
+- `@space p-*;`
+- `@space pt-*;`
+- `@space pb-*;`
+- `@space pl-*;`
+- `@space pr-*;`
+- `@space px-*;`
+- `@space py-*;`
+- `@space pbl-*;`
+- `@space pbls-*;`
+- `@space pble-*;`
+- `@space pi-*;`
+- `@space pis-*;`
+- `@space pie-*;`
 
 <Alert variant="info">
 
@@ -27,86 +43,86 @@ const shilpConfig = {
 
 	properties: {
 		space: {
-			m: {
-				property: "margin: <n><v><i>;",
+			p: {
+				property: "padding: <n><v><i>;",
 				resolve: "spacing",
 				themeKey: "spacingPixels",
 				values: {},
 			},
-			mt: {
-				property: "margin-top: <n><v><i>;",
+			pt: {
+				property: "padding-top: <n><v><i>;",
 				resolve: "spacing",
 				themeKey: "spacingPixels",
 				values: {},
 			},
-			mr: {
-				property: "margin-right: <n><v><i>;",
+			pr: {
+				property: "padding-right: <n><v><i>;",
 				resolve: "spacing",
 				themeKey: "spacingPixels",
 				values: {},
 			},
-			mb: {
-				property: "margin-bottom: <n><v><i>;",
+			pb: {
+				property: "padding-bottom: <n><v><i>;",
 				resolve: "spacing",
 				themeKey: "spacingPixels",
 				values: {},
 			},
-			ml: {
-				property: "margin-left: <n><v><i>;",
+			pl: {
+				property: "padding-left: <n><v><i>;",
 				resolve: "spacing",
 				themeKey: "spacingPixels",
 				values: {},
 			},
-			mx: {
+			px: {
 				property: `
-					margin-left: <n><v><i>;
-          margin-right: <n><v><i>;
+					padding-left: <n><v><i>;
+          padding-right: <n><v><i>;
         `,
 				resolve: "spacing",
 				themeKey: "spacingPixels",
 				values: {},
 			},
-			my: {
+			py: {
 				property: `
-					margin-top: <n><v><i>;
-          margin-bottom: <n><v><i>;
+					padding-top: <n><v><i>;
+          padding-bottom: <n><v><i>;
         `,
 				resolve: "spacing",
 				themeKey: "spacingPixels",
 				values: {},
 			},
-			mbl: {
-				property: "margin-block: <n><v><i>",
+			pbl: {
+				property: "padding-block: <n><v><i>",
 				resolve: "spacing",
 				themeKey: "spacingPixels",
 				values: {},
 			},
-			mbls: {
-				property: "margin-block-start: <n><v><i>;",
+			pbls: {
+				property: "padding-block-start: <n><v><i>;",
 				resolve: "spacing",
 				themeKey: "spacingPixels",
 				values: {},
 			},
-			mble: {
-				property: "margin-block-end: <n><v><i>;",
+			pble: {
+				property: "padding-block-end: <n><v><i>;",
 				resolve: "spacing",
 				themeKey: "spacingPixels",
 				values: {},
 			},
-			mi: {
-				property: "margin-inline: <n><v><i>",
+			pi: {
+				property: "padding-inline: <n><v><i>",
 				resolve: "spacing",
 				themeKey: "spacingPixels",
 				values: {},
 			},
-			mis: {
-				property: "margin-inline-start: <n><v><i>;",
+			pis: {
+				property: "padding-inline-start: <n><v><i>;",
 				resolve: "spacing",
 				themeKey: "spacingPixels",
 				values: {},
 			},
-			mie: {
-				property: "margin-inline-end: <n><v><i>;",
+			pie: {
+				property: "padding-inline-end: <n><v><i>;",
 				resolve: "spacing",
 				themeKey: "spacingPixels",
 				values: {},

--- a/apps/docs/src/content/docs/properties/svg/fill.mdx
+++ b/apps/docs/src/content/docs/properties/svg/fill.mdx
@@ -1,12 +1,17 @@
 ---
-title: "Fill Color | @svg"
-description: "Set SVG element fill color."
-keywords: ["svg", "fill", "color", "vector", "css"]
+title: "SVG Fill Color and Opacity | @svg"
+description: "Set SVG element's fill color and opacity."
+keywords: ["svg", "fill", "color", "vector"]
 ---
 
-# fill
+# SVG Fill Color and Opacity
 
-controls SVG shape
+Set SVG element's fill color and opacity.
+
+Usage:
+
+- `@svg fill-*;`
+- `@svg fill-opacity-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/svg/index.mdx
+++ b/apps/docs/src/content/docs/properties/svg/index.mdx
@@ -12,7 +12,7 @@ SVG intent contains `svg` related utilities.
 
 Utilities available in `@svg` intent are listed below.
 
-| Utility    | Description          | Documentation                         |
-| ---------- | -------------------- | ------------------------------------- |
-| `fill-*`   | controls SVG shape   | [fill](/docs/properties/svg/fill)     |
-| `stroke-*` | controls SVG outline | [stroke](/docs/properties/svg/stroke) |
+| Utility    | Description                                                                    | Documentation                         |
+| ---------- | ------------------------------------------------------------------------------ | ------------------------------------- |
+| `fill-*`   | Set SVG element's fill color and opacity.                                      | [fill](/docs/properties/svg/fill)     |
+| `stroke-*` | Set SVG element's stroke thickness (width), color, opacity and scaling effect. | [stroke](/docs/properties/svg/stroke) |

--- a/apps/docs/src/content/docs/properties/svg/stroke.mdx
+++ b/apps/docs/src/content/docs/properties/svg/stroke.mdx
@@ -1,12 +1,21 @@
 ---
-title: "Stroke Properties | @svg"
-description: "Set SVG element stroke properties."
-keywords: ["svg", "stroke", "outline", "vector", "css"]
+title: "SVG Stroke | @svg"
+description:
+  "Set SVG element's stroke thickness (width), color, opacity and scaling
+  effect."
+keywords: ["svg", "stroke", "outline", "vector"]
 ---
 
-# stroke
+# SVG Stroke
 
-controls SVG outline
+Set SVG element's stroke thickness (width), color, opacity and scaling effect.
+
+Usage:
+
+- `@svg stroke-*;`
+- `@svg stroke-color-*;`
+- `@svg stroke-opacity-*;`
+- `@svg stroke-scale-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/table/_layout.mdx
+++ b/apps/docs/src/content/docs/properties/table/_layout.mdx
@@ -1,12 +1,16 @@
 ---
-title: "Table Layout Algorithm | @table"
-description: "Control table layout algorithm."
-keywords: ["table", "layout", "algorithm", "cells", "css"]
+title: "Table Layout | @table"
+description: "Control table's dimentions with column sizing algorithm."
+keywords: ["table", "layout", "algorithm", "cells"]
 ---
 
-# layout
+# Table Layout
 
-controls table column sizing algorithm
+Control table's dimentions with column sizing algorithm.
+
+Usage:
+
+- `@table layout-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/table/border.mdx
+++ b/apps/docs/src/content/docs/properties/table/border.mdx
@@ -1,12 +1,16 @@
 ---
-title: "Table Border | @table"
-description: "Set table borders styling."
-keywords: ["table", "border", "styling", "cells", "css"]
+title: "Table Border Effect | @table"
+description: "Controls border effect for table's cells."
+keywords: ["table", "border", "styling", "cells"]
 ---
 
-# border
+# Table Border Effect
 
-controls table borders are separated or collapsed
+Controls border effect for table's cells.
+
+Usage:
+
+- `@table border-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/table/caption.mdx
+++ b/apps/docs/src/content/docs/properties/table/caption.mdx
@@ -1,12 +1,16 @@
 ---
-title: "Table Caption | @table"
-description: "Style table caption elements."
-keywords: ["table", "caption", "styling", "label", "css"]
+title: "Table Caption Position | @table"
+description: "Set position of a table’s caption (top or bottom)."
+keywords: ["table", "caption", "styling", "label"]
 ---
 
-# caption
+# Table Caption Position
 
-position of a table’s caption
+Set position of a table’s caption (top or bottom).
+
+Usage:
+
+- `@table caption-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/table/gap.mdx
+++ b/apps/docs/src/content/docs/properties/table/gap.mdx
@@ -1,12 +1,16 @@
 ---
-title: "Table Gap | @table"
-description: "Control table cell gap spacing."
-keywords: ["table", "gap", "spacing", "cells", "css"]
+title: "Spacing Between Table Cells | @table"
+description: "Control spacing between table's cells."
+keywords: ["table", "gap", "spacing", "cells"]
 ---
 
-# gap
+# Spacing Between Table Cells
 
-distance between table borders
+Control spacing between table's cells.
+
+Usage:
+
+- `@table gap-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/table/index.mdx
+++ b/apps/docs/src/content/docs/properties/table/index.mdx
@@ -1,8 +1,8 @@
 ---
 title: "Table Intent - Table Layout"
 description:
-  "Table styling with @table intent. Table layout, border-collapse, and table
-  properties."
+  "Table styling with @table intent. Table's caption position, cells border
+  effect and spacing."
 keywords:
   ["@table", "table", "table layout", "border collapse", "table styling"]
 ---
@@ -13,9 +13,9 @@ Table intent contains `table` layout related utilities.
 
 Utilities available in `@table` intent are listed below.
 
-| Utility     | Description                                       | Documentation                             |
-| ----------- | ------------------------------------------------- | ----------------------------------------- |
-| `border-*`  | controls table borders are separated or collapsed | [border](/docs/properties/table/border)   |
-| `caption-*` | position of a table’s caption                     | [caption](/docs/properties/table/caption) |
-| `gap-*`     | distance between table borders                    | [gap](/docs/properties/table/gap)         |
-| `layout-*`  | controls table column sizing algorithm            | [layout](/docs/properties/table/layout)   |
+| Utility     | Description                                              | Documentation                             |
+| ----------- | -------------------------------------------------------- | ----------------------------------------- |
+| `border-*`  | Controls border effect for table's cells.                | [border](/docs/properties/table/border)   |
+| `caption-*` | Set position of a table’s caption (top or bottom).       | [caption](/docs/properties/table/caption) |
+| `gap-*`     | Control spacing between table's cells.                   | [gap](/docs/properties/table/gap)         |
+| `layout-*`  | Control table's dimentions with column sizing algorithm. | [layout](/docs/properties/table/layout)   |

--- a/apps/docs/src/content/docs/properties/text/align.mdx
+++ b/apps/docs/src/content/docs/properties/text/align.mdx
@@ -1,12 +1,17 @@
 ---
 title: "Text Alignment | @text"
-description: "Align text content within elements."
-keywords: ["text", "align", "alignment", "justify", "css"]
+description: "Align text content within element along main-axis and cross-axis."
+keywords: ["text", "align", "alignment", "justify"]
 ---
 
-# align
+# Align Text
 
-vertical alignment of text (cross axis)
+Align text content within element along main-axis and cross-axis.
+
+Usage:
+
+- `@text align-x-*;`
+- `@text align-y-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/text/break.mdx
+++ b/apps/docs/src/content/docs/properties/text/break.mdx
@@ -1,12 +1,16 @@
 ---
-title: "Text Break and Wrap | @text"
+title: "Text Break | @text"
 description: "Control text breaking and word wrapping."
-keywords: ["text", "break", "wrap", "overflow", "css"]
+keywords: ["text", "break", "wrap", "overflow"]
 ---
 
-# break
+# Text Break
 
-position of a text’s break
+Control text breaking and word wrapping.
+
+Usage:
+
+- `@text break-*;`
 
 <Alert variant="info">
 
@@ -61,13 +65,13 @@ const shilpConfig = {
 					special: true,
 					values: {
 						DEFAULT: `
-					overflow-wrap: normal<i>;
-					word-break: normal<i>;
-				`,
+							overflow-wrap: normal<i>;
+							word-break: normal<i>;
+						`,
 						unset: `
-					overflow-wrap: unset<i>;
-					word-break: unset<i>;
-				`,
+							overflow-wrap: unset<i>;
+							word-break: unset<i>;
+						`,
 					},
 				},
 

--- a/apps/docs/src/content/docs/properties/text/case.mdx
+++ b/apps/docs/src/content/docs/properties/text/case.mdx
@@ -1,12 +1,16 @@
 ---
 title: "Text Case | @text"
 description: "Transform text case to upper, lower, or capitalize."
-keywords: ["text", "case", "transform", "upper", "css"]
+keywords: ["text", "case", "transform", "upper"]
 ---
 
-# case
+# Text Case
 
-distance between text borders
+Transform text case to upper, lower, or capitalize.
+
+Usage:
+
+- `@text case-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/text/color.mdx
+++ b/apps/docs/src/content/docs/properties/text/color.mdx
@@ -1,12 +1,16 @@
 ---
 title: "Text Color | @text"
 description: "Set text color for elements."
-keywords: ["text", "color", "foreground", "typography", "css"]
+keywords: ["text", "color", "foreground", "typography"]
 ---
 
-# color
+# Text Color
 
-controls text column sizing algorithm
+Set text color for elements.
+
+Usage:
+
+- `@text color-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/text/content.mdx
+++ b/apps/docs/src/content/docs/properties/text/content.mdx
@@ -1,12 +1,16 @@
 ---
-title: "Text Content Display | @text"
-description: "Control text content display and overflow."
-keywords: ["text", "content", "display", "overflow", "css"]
+title: "Text Content for pseudo-elements | @text"
+description: "Set text content for pseudo-elements (::before and ::after)."
+keywords: ["text", "content", "display", "overflow"]
 ---
 
-# content
+# Text Content For Pseudo Elements
 
-controls text column sizing algorithm
+Set text content for pseudo-elements (`::before` and `::after`).
+
+Usage:
+
+- `@text content-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/text/family.mdx
+++ b/apps/docs/src/content/docs/properties/text/family.mdx
@@ -1,12 +1,16 @@
 ---
 title: "Font Family | @text"
 description: "Set font family for text elements."
-keywords: ["text", "family", "font", "typeface", "css"]
+keywords: ["text", "family", "font", "typeface"]
 ---
 
-# family
+# Font Family
 
-controls text column sizing algorithm
+Set font family for text elements.
+
+Usage:
+
+- `@text family-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/text/gap.mdx
+++ b/apps/docs/src/content/docs/properties/text/gap.mdx
@@ -1,12 +1,17 @@
 ---
-title: "Letter Spacing | @text"
-description: "Control text gap and letter spacing."
-keywords: ["text", "gap", "spacing", "letter", "css"]
+title: "Spacing Between Texts | @text"
+description: "Control spacing between letters and words."
+keywords: ["text", "gap", "spacing", "letter"]
 ---
 
-# gap
+# Spacing Between Texts
 
-controls text column sizing algorithm
+Control spacing between letters and words.
+
+Usage:
+
+- `@text gap-*;`
+- `@text gap-word-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/text/h.mdx
+++ b/apps/docs/src/content/docs/properties/text/h.mdx
@@ -1,12 +1,16 @@
 ---
-title: "Backdrop Blur Filter | @filter"
-description: "Apply backdrop blur filter effect to elements."
-keywords: ["filter", "backdrop", "blur", "effect", "css"]
+title: "Line Height | @text"
+description: "Set line height."
+keywords: ["text", "line-height", "spacing", "typography"]
 ---
 
-# backdrop blur
+# Line Height
 
-blur backdrop filter
+Set line height.
+
+Usage:
+
+- `@text h-*;`
 
 <Alert variant="info">
 
@@ -26,13 +30,17 @@ const shilpConfig = {
 	source: "react",
 
 	properties: {
-		filter: {
-			backdrop: {
-				blur: {
-					property: "backdrop-filter: blur(<v>)<i>;",
-					resolve: "spacing",
-					themeKey: "blur",
-					values: {},
+		text: {
+			h: {
+				property: "line-height: <v><i>;",
+				values: {
+					normal: 1,
+					xs: 1.25,
+					sm: 1.375,
+					base: 1.5,
+					md: 1.625,
+					lg: 1.75,
+					xl: 2,
 				},
 			},
 		},

--- a/apps/docs/src/content/docs/properties/text/index.mdx
+++ b/apps/docs/src/content/docs/properties/text/index.mdx
@@ -13,23 +13,23 @@ Text intent contains **element's typography** related utilities.
 
 Utilities available in `@text` intent are listed below.
 
-| Utility      | Description                             | Documentation                                    |
-| ------------ | --------------------------------------- | ------------------------------------------------ |
-| `align-*`    | vertical alignment of text (cross axis) | [align](/docs/properties/text/align)             |
-| `break-*`    | position of a text’s break              | [break](/docs/properties/text/break)             |
-| `case-*`     | distance between text borders           | [case](/docs/properties/text/case)               |
-| `color-*`    | controls text column sizing algorithm   | [color](/docs/properties/text/color)             |
-| `content-*`  | controls text column sizing algorithm   | [content](/docs/properties/text/content)         |
-| `family-*`   | controls text column sizing algorithm   | [family](/docs/properties/text/family)           |
-| `gap-*`      | controls text column sizing algorithm   | [gap](/docs/properties/text/gap)                 |
-| `h-*`        | controls text column sizing algorithm   | [line height](/docs/properties/text/line-height) |
-| `line-*`     | controls text column sizing algorithm   | [line](/docs/properties/text/line)               |
-| `lines-*`    | controls text column sizing algorithm   | [lines](/docs/properties/text/lines)             |
-| `move-*`     | controls text column sizing algorithm   | [move](/docs/properties/text/move)               |
-| `nums-*`     | controls text column sizing algorithm   | [nums](/docs/properties/text/nums)               |
-| `overflow-*` | controls text column sizing algorithm   | [overflow](/docs/properties/text/overflow)       |
-| `shadow-*`   | controls text column sizing algorithm   | [shadow](/docs/properties/text/shadow)           |
-| `size-*`     | controls text column sizing algorithm   | [size](/docs/properties/text/size)               |
-| `space-*`    | controls text column sizing algorithm   | [space](/docs/properties/text/space)             |
-| `style-*`    | controls text column sizing algorithm   | [style](/docs/properties/text/style)             |
-| `thick-*`    | controls text column sizing algorithm   | [thick](/docs/properties/text/thick)             |
+| Utility      | Description                                                       | Documentation                              |
+| ------------ | ----------------------------------------------------------------- | ------------------------------------------ |
+| `align-*`    | Align text content within element along main-axis and cross-axis. | [align](/docs/properties/text/align)       |
+| `break-*`    | Control text breaking and word wrapping.                          | [break](/docs/properties/text/break)       |
+| `case-*`     | Transform text case to upper, lower, or capitalize.               | [case](/docs/properties/text/case)         |
+| `color-*`    | Set text color for elements.                                      | [color](/docs/properties/text/color)       |
+| `content-*`  | Set text content for pseudo-elements (`::before` and `::after`).  | [content](/docs/properties/text/content)   |
+| `family-*`   | Set font family for text elements.                                | [family](/docs/properties/text/family)     |
+| `gap-*`      | Control spacing between letters and words.                        | [gap](/docs/properties/text/gap)           |
+| `h-*`        | Set line height.                                                  | [h](/docs/properties/text/h)               |
+| `line-*`     | Control text decoration (line).                                   | [line](/docs/properties/text/line)         |
+| `lines-*`    | Control number of visible text lines (clamping).                  | [lines](/docs/properties/text/lines)       |
+| `move-*`     | Set empty space (indentation) before text block (lines).          | [move](/docs/properties/text/move)         |
+| `nums-*`     | Set numeric glyph styling (tabular, lining, etc.)                 | [nums](/docs/properties/text/nums)         |
+| `overflow-*` | Handle overflowing text.                                          | [overflow](/docs/properties/text/overflow) |
+| `shadow-*`   | Add text shadow effects.                                          | [shadow](/docs/properties/text/shadow)     |
+| `size-*`     | Set text size for text elements.                                  | [size](/docs/properties/text/size)         |
+| `space-*`    | Control white space in text.                                      | [space](/docs/properties/text/space)       |
+| `style-*`    | Set text style for text elements.                                 | [style](/docs/properties/text/style)       |
+| `thick-*`    | Set text's thickness (weight).                                    | [thick](/docs/properties/text/thick)       |

--- a/apps/docs/src/content/docs/properties/text/line.mdx
+++ b/apps/docs/src/content/docs/properties/text/line.mdx
@@ -1,12 +1,20 @@
 ---
-title: "Text Line Properties | @text"
-description: "Control text line properties and behavior."
-keywords: ["text", "line", "break", "wrap", "css"]
+title: "Text Decoration (Line) | @text"
+description: "Control text decoration (line)."
+keywords: ["text", "line", "break", "wrap"]
 ---
 
-# line
+# Text Decoration (Line)
 
-controls text column sizing algorithm
+Control text decoration (line).
+
+Usage:
+
+- `@text line-is-*;`
+- `@text line-thick-*;`
+- `@text line-color-*;`
+- `@text line-style-*;`
+- `@text line-offset-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/text/lines.mdx
+++ b/apps/docs/src/content/docs/properties/text/lines.mdx
@@ -1,12 +1,18 @@
 ---
-title: "Line Clamp | @text"
-description: "Control text line clipping and clamping."
-keywords: ["text", "lines", "clamp", "overflow", "css"]
+title: "Visible Lines OR Line Clamp | @text"
+description: "Control number of visible text lines (clamping)."
+keywords: ["text", "lines", "clamp", "overflow"]
 ---
 
-# lines
+# Visible Lines OR Line Clamp
 
-controls text column sizing algorithm
+Control number of visible text lines (clamping).
+
+Usage:
+
+- `@text lines-*;`
+- `@text lines-all;`
+- `@text lines-all-unset;`
 
 <Alert variant="info">
 
@@ -43,17 +49,17 @@ const shilpConfig = {
 					special: true,
 					values: {
 						visible: `
-					overflow: visible<i>;
-					display: block<i>;
-					-webkit-box-orient: horizontal<i>;
-					--lines: none<i>;
-				`,
+							overflow: visible<i>;
+							display: block<i>;
+							-webkit-box-orient: horizontal<i>;
+							--lines: none<i>;
+						`,
 						unset: `
-					overflow: unset<i>;
-					display: unset<i>;
-					-webkit-box-orient: unset<i>;
-					--lines: unset<i>;
-				`,
+							overflow: unset<i>;
+							display: unset<i>;
+							-webkit-box-orient: unset<i>;
+							--lines: unset<i>;
+						`,
 					},
 				},
 			},

--- a/apps/docs/src/content/docs/properties/text/meta.json
+++ b/apps/docs/src/content/docs/properties/text/meta.json
@@ -11,7 +11,7 @@
 		"content",
 		"family",
 		"gap",
-		"line-height",
+		"h",
 		"line",
 		"lines",
 		"move",

--- a/apps/docs/src/content/docs/properties/text/move.mdx
+++ b/apps/docs/src/content/docs/properties/text/move.mdx
@@ -1,12 +1,16 @@
 ---
-title: "Text Position Offset | @text"
-description: "Apply text positioning and movement."
-keywords: ["text", "move", "position", "offset", "css"]
+title: "Text Indentation | @text"
+description: "Set empty space (indentation) before text block (lines)."
+keywords: ["text", "move", "position", "offset"]
 ---
 
-# move
+# Text Indentation
 
-controls text column sizing algorithm
+Set empty space (indentation) before text block (lines).
+
+Usage:
+
+- `@text move-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/text/nums.mdx
+++ b/apps/docs/src/content/docs/properties/text/nums.mdx
@@ -1,12 +1,16 @@
 ---
 title: "Numeric Formatting | @text"
-description: "Control numeric text formatting."
-keywords: ["text", "numbers", "numeric", "format", "css"]
+description: "Set numeric glyph styling (tabular, lining, etc.)"
+keywords: ["text", "numbers", "numeric", "format"]
 ---
 
-# nums
+# Numeric Formatting
 
-controls text column sizing algorithm
+Set numeric glyph styling (tabular, lining, etc.).
+
+Usage:
+
+- `@text nums-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/text/overflow.mdx
+++ b/apps/docs/src/content/docs/properties/text/overflow.mdx
@@ -1,12 +1,18 @@
 ---
 title: "Text Overflow | @text"
-description: "Handle text overflow with ellipsis."
-keywords: ["text", "overflow", "ellipsis", "truncate", "css"]
+description: "Handle overflowing text."
+keywords: ["text", "overflow", "ellipsis", "truncate"]
 ---
 
-# overflow
+# Text Overflow
 
-controls text column sizing algorithm
+Handle overflowing text.
+
+Usage:
+
+- `@text overflow-*;`
+- `@text overflow-truncate;`
+- `@text overflow-truncate-unset;`
 
 <Alert variant="info">
 
@@ -41,15 +47,15 @@ const shilpConfig = {
 					special: true,
 					values: {
 						DEFAULT: `
-					overflow: hidden<i>;
-					text-overflow: ellipsis<i>;
-					white-space: nowrap<i>;
-				`,
+							overflow: hidden<i>;
+							text-overflow: ellipsis<i>;
+							white-space: nowrap<i>;
+						`,
 						unset: `
-					overflow: unset<i>;
-					text-overflow: unset<i>;
-					white-space: unset<i>;
-				`,
+							overflow: unset<i>;
+							text-overflow: unset<i>;
+							white-space: unset<i>;
+						`,
 					},
 				},
 			},

--- a/apps/docs/src/content/docs/properties/text/shadow.mdx
+++ b/apps/docs/src/content/docs/properties/text/shadow.mdx
@@ -1,12 +1,18 @@
 ---
 title: "Text Shadow | @text"
 description: "Add text shadow effects."
-keywords: ["text", "shadow", "effect", "depth", "css"]
+keywords: ["text", "shadow", "effect", "depth"]
 ---
 
-# shadow
+# Text Shadow
 
-controls text column sizing algorithm
+Add text shadow effects.
+
+Usage:
+
+- `@text shadow;`
+- `@text shadow-*;`
+- `@text shadow-color-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/text/size.mdx
+++ b/apps/docs/src/content/docs/properties/text/size.mdx
@@ -1,12 +1,16 @@
 ---
-title: "Font Size | @text"
-description: "Set font size for text elements."
-keywords: ["text", "size", "font", "typography", "css"]
+title: "Text Size | @text"
+description: "Set text size for text elements."
+keywords: ["text", "size", "font", "typography"]
 ---
 
-# size
+# Text Size
 
-controls text column sizing algorithm
+Set text size for text elements.
+
+Usage:
+
+- `@text size-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/text/space.mdx
+++ b/apps/docs/src/content/docs/properties/text/space.mdx
@@ -1,12 +1,16 @@
 ---
-title: "Text Spacing | @text"
-description: "Control text spacing properties."
-keywords: ["text", "space", "spacing", "gap", "css"]
+title: "White Space | @text"
+description: "Control white space in text."
+keywords: ["text", "space", "spacing", "gap"]
 ---
 
-# space
+# White Space
 
-controls text column sizing algorithm
+Control white space in text.
+
+Usage:
+
+- `@text space-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/text/style.mdx
+++ b/apps/docs/src/content/docs/properties/text/style.mdx
@@ -1,12 +1,16 @@
 ---
-title: "Font Style | @text"
-description: "Set font style for text elements."
-keywords: ["text", "style", "italic", "font", "css"]
+title: "Text Style | @text"
+description: "Set text style for text elements."
+keywords: ["text", "style", "italic", "font"]
 ---
 
-# style
+# Text Style
 
-controls text column sizing algorithm
+Set text style for text elements.
+
+Usage:
+
+- `@text style-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/properties/text/thick.mdx
+++ b/apps/docs/src/content/docs/properties/text/thick.mdx
@@ -1,12 +1,16 @@
 ---
-title: "Font Weight | @text"
-description: "Control text font weight thickness."
-keywords: ["text", "thick", "weight", "bold", "css"]
+title: "Text Thickness (Weight) | @text"
+description: "Set text's thickness (weight)."
+keywords: ["text", "thick", "weight", "bold"]
 ---
 
-# thick
+# Text Thickness (Weight)
 
-controls text column sizing algorithm
+Set text's thickness (weight).
+
+Usage:
+
+- `@text thick-*;`
 
 <Alert variant="info">
 

--- a/apps/docs/src/content/docs/values/angles.mdx
+++ b/apps/docs/src/content/docs/values/angles.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Angles Dataset"
-description: "Angle values for rotation, skew, and transform operations."
+description: "Angle values for rotation, skew, and other transform operations."
 keywords: ["values", "angles", "degrees", "transform", "css"]
 ---
 

--- a/apps/docs/src/content/docs/values/blend.mdx
+++ b/apps/docs/src/content/docs/values/blend.mdx
@@ -1,12 +1,22 @@
 ---
 title: "Blend Dataset"
-description: "Blend mode values for mix-blend-mode and compositing."
-keywords: ["values", "blend", "mix-blend-mode", "compositing", "css"]
+description: "Blend mode values for background and mix blend mode, compositing."
+keywords:
+  [
+    "values",
+    "blend",
+    "mix",
+    "mix-blend-mode",
+    "background-blend-mode",
+    "compositing",
+    "css",
+  ]
 ---
 
 # Blend Dataset
 
-The **Blend dataset** defines values used for **CSS blend modes**.
+The **Blend dataset** defines values used for blend modes: **background and
+mix**.
 
 ---
 

--- a/apps/docs/src/content/docs/values/flow.mdx
+++ b/apps/docs/src/content/docs/values/flow.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Flow Dataset"
-description: "Flow direction values for layout properties."
-keywords: ["values", "flow", "direction", "layout", "css"]
+description: "Bezier-curves for animation and transition properties."
+keywords: ["values", "flow", "bezier-curve", "animation", "transition", "css"]
 ---
 
 # Flow Dataset

--- a/apps/docs/src/content/docs/values/index.mdx
+++ b/apps/docs/src/content/docs/values/index.mdx
@@ -39,18 +39,18 @@ This section lists all built-in values datasets shipped with Shilp CSS.
 
 Each dataset has its own page that documents the dataset structure and usage.
 
-| Dataset       | Description                                                  | Documentation                                       |
-| ------------- | ------------------------------------------------------------ | --------------------------------------------------- |
-| Angles        | Angle values used for rotation and transform related styles. | [Angles Dataset](/docs/values/angles)               |
-| Blend         | Blend-mode values used for compositing and visual effects.   | [Blend Dataset](/docs/values/blend)                 |
-| Border        | Border width, style and radius related values.               | [Border Dataset](/docs/values/border)               |
-| Colors        | Full color palette used across the design system.            | [Colors Dataset](/docs/values/colors)               |
-| Filter        | Filter values used for blur, brightness and similar effects. | [Filter Dataset](/docs/values/filter)               |
-| Flex-Grid     | Values used by flexbox and grid layout utilities.            | [Flex-Grid Dataset](/docs/values/flex-grid)         |
-| Flow          | Timing functions used for animations and transitions.        | [Flow Dataset](/docs/values/flow)                   |
-| Global Values | Standard CSS global keywords like `inherit`, `unset`, etc.   | [Global Values Dataset](/docs/values/global-values) |
-| Numbers       | Generic numeric values reused across utilities.              | [Numbers Dataset](/docs/values/numbers)             |
-| Spacing       | Spacing scale used for margins, padding, etc.                | [Spacing Dataset](/docs/values/spacing)             |
-| Time          | Duration values used for transitions and animations.         | [Time Dataset](/docs/values/time)                   |
+| Dataset       | Description                                                       | Documentation                                       |
+| ------------- | ----------------------------------------------------------------- | --------------------------------------------------- |
+| Angles        | Angle values for rotation, skew, and other transform operations.  | [Angles Dataset](/docs/values/angles)               |
+| Blend         | Blend mode values for background and mix blend mode, compositing. | [Blend Dataset](/docs/values/blend)                 |
+| Border        | Border property values for styling borders.                       | [Border Dataset](/docs/values/border)               |
+| Colors        | Color value tokens for consistent color theming.                  | [Colors Dataset](/docs/values/colors)               |
+| Filter        | Filter effect values for visual effects.                          | [Filter Dataset](/docs/values/filter)               |
+| Flex-Grid     | Layout values for flexbox and CSS grid systems.                   | [Flex-Grid Dataset](/docs/values/flex-grid)         |
+| Flow          | Bezier-curvers for animation and transition properties.           | [Flow Dataset](/docs/values/flow)                   |
+| Global Values | Global CSS values used across all properties.                     | [Global Values Dataset](/docs/values/global-values) |
+| Numbers       | Numeric value tokens for dimensions and quantities.               | [Numbers Dataset](/docs/values/numbers)             |
+| Spacing       | Spacing value tokens for padding, margin and other properties.    | [Spacing Dataset](/docs/values/spacing)             |
+| Time          | Time value tokens for animation and transition timing.            | [Time Dataset](/docs/values/time)                   |
 
 </section>

--- a/apps/docs/src/content/docs/values/spacing.mdx
+++ b/apps/docs/src/content/docs/values/spacing.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Spacing Dataset"
-description: "Spacing value tokens for padding and margin."
+description: "Spacing value tokens for padding, margin and other properties."
 keywords: ["values", "spacing", "margin", "padding", "css"]
 ---
 

--- a/apps/docs/src/lib/content.js
+++ b/apps/docs/src/lib/content.js
@@ -175,7 +175,7 @@ class Content {
 		}
 
 		const label = file.label || slug.replace(/-/g, " ");
-		const title = file.title || label;
+		const title = file.title;
 
 		const fileMeta = {
 			type: "file",
@@ -208,7 +208,7 @@ class Content {
 		const isPage = childMeta.page;
 		const slug = childMeta.slug || folderName; // will be ignored if virtual
 		const label = childMeta.label || slug.replace(/-/g, " ");
-		const title = childMeta.title || label;
+		const title = childMeta.title;
 
 		let slugs = parentSlugs;
 

--- a/apps/docs/src/styles/components/docs/topics.css
+++ b/apps/docs/src/styles/components/docs/topics.css
@@ -31,7 +31,8 @@
 			[data-folder="components"],
 			[data-folder="properties"],
 			[data-folder="mixins"],
-			[data-folder="default styles"]
+			[data-folder="default styles"],
+			[data-folder="changelog"]
 		)
 		a {
 		@text case-inherit;
@@ -51,14 +52,14 @@
 [data-folder-page] ul {
 	@space pl-5;
 
-	li {
+	a {
 		@position is-relative;
 
 		@self before {
 			content: "-";
 
 			@position is-absolute top-1/2;
-			@adjust preset -move-y-1/2 -move-x-2.5;
+			@adjust preset -move-y-1/2 -move-x-5;
 		}
 	}
 }


### PR DESCRIPTION
* refactor: separate **backdrop filter** from **filter**

- create a new folder in content and moved backdrop related filters
- move indent indicator from `li` to `li a` for `data-folder-page`

* fix: add correct description for text intent's utilites

* refactor: titles, descriptions | feat: add basic usage example

* fix: yml formatting

* refactor: docs topics navigation label

- make properties labels match first utility token
  - links url and text changed accordingly
  - for `scroll-m` and `scroll-p`, an additional label is required
- exlude `/docs/changelog` from `uppercase` styles
- removed files and folder `title` to be inherited from `label`

* feat: add basic usage example for mixins

- update changelog and bump the docs version